### PR TITLE
Improve camelCase to kebab-case conversion with proper acronym handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,14 +262,20 @@ The macro automatically generates:
 - The aggregate state struct (`BankAccountAggregate`)
 - The command enum (`BankAccountAggregateCommand`)
 - The event enum with `Event` trait (`BankAccountAggregateEvent`)
-- The URN type (`BankAccountAggregateUrn`)
+- The URN type (`BankAccountAggregateUrn`) with helper methods:
+  - `YourTypeUrn::new(id)` - Creates a URN with the configured namespace
+  - `YourTypeUrn::parse(input)` - Parses a URN string and validates the namespace
+  - `YourTypeUrn::namespace()` - Returns the namespace identifier as a static string
+  - `Display` implementation for easy string conversion
 - A services placeholder struct (`BankAccountAggregateServices`)
 
 This reduces boilerplate while keeping the same functionality. You still need to implement the `EventStream` and `Aggregate` traits to define the behavior.
 
-### Optional Namespace Configuration
+### URN Namespace Configuration
 
-You can optionally specify a `namespace` to configure the URN namespace identifier (NID) for your aggregate. This adds convenient helper methods to the URN type:
+The URN namespace identifier (NID) is automatically derived from the aggregate name by converting CamelCase to kebab-case (e.g., `BankAccount` becomes `bank-account`, `HTTPConnection` becomes `http-connection`).
+
+You can optionally specify a custom `namespace` to override this default behavior:
 
 ```rust
 define_aggregate! {
@@ -288,7 +294,7 @@ define_aggregate! {
     }
 }
 
-// With namespace configured, you get helper methods:
+// The URN helper methods are always available:
 let customer_urn = CustomerUrn::new("peter@example.com").unwrap();
 assert_eq!(customer_urn.to_string(), "urn:customer:peter@example.com");
 
@@ -296,8 +302,4 @@ assert_eq!(customer_urn.to_string(), "urn:customer:peter@example.com");
 assert_eq!(CustomerUrn::namespace(), "customer");
 ```
 
-When `namespace` is specified, the macro generates:
-
-- `YourTypeUrn::new(id)` - Creates a URN with the configured namespace
-- `YourTypeUrn::namespace()` - Returns the namespace identifier as a static string
-- `Display` implementation for easy string conversion
+If no custom namespace is specified, the namespace will be automatically derived from the aggregate name (e.g., `BankAccount` → `bank-account`).

--- a/es/tests/aggregate_macro_test.rs
+++ b/es/tests/aggregate_macro_test.rs
@@ -212,4 +212,88 @@ mod tests {
         // Verify namespace method
         assert_eq!(CustomerUrn::namespace(), "my-customer");
     }
+
+    // Test proper camelCase to kebab-case conversion including acronym handling
+    #[test]
+    fn test_aggregate_namespace_conversion() {
+        // Test simple camelCase
+        define_aggregate! {
+            BankAccount {
+                state: { value: i32 },
+                commands: { DoSomething },
+                events: { SomethingDone }
+            }
+        }
+        assert_eq!(BankAccountUrn::namespace(), "bank-account");
+
+        // Test leading acronym
+        define_aggregate! {
+            HTTPConnection {
+                state: { value: i32 },
+                commands: { DoSomething },
+                events: { SomethingDone }
+            }
+        }
+        assert_eq!(HTTPConnectionUrn::namespace(), "http-connection");
+
+        // Test trailing acronym
+        define_aggregate! {
+            ConnectionHTTP {
+                state: { value: i32 },
+                commands: { DoSomething },
+                events: { SomethingDone }
+            }
+        }
+        assert_eq!(ConnectionHTTPUrn::namespace(), "connection-http");
+
+        // Test middle acronym
+        define_aggregate! {
+            MyHTTPServer {
+                state: { value: i32 },
+                commands: { DoSomething },
+                events: { SomethingDone }
+            }
+        }
+        assert_eq!(MyHTTPServerUrn::namespace(), "my-http-server");
+
+        // Test single word
+        define_aggregate! {
+            Account {
+                state: { value: i32 },
+                commands: { DoSomething },
+                events: { SomethingDone }
+            }
+        }
+        assert_eq!(AccountUrn::namespace(), "account");
+
+        // Test all caps word
+        define_aggregate! {
+            API {
+                state: { value: i32 },
+                commands: { DoSomething },
+                events: { SomethingDone }
+            }
+        }
+        assert_eq!(APIUrn::namespace(), "api");
+
+        // Test multiple acronyms
+        define_aggregate! {
+            HTTPSAPIGateway {
+                state: { value: i32 },
+                commands: { DoSomething },
+                events: { SomethingDone }
+            }
+        }
+        assert_eq!(HTTPSAPIGatewayUrn::namespace(), "httpsapi-gateway");
+
+        // Test consecutive caps followed by lowercase
+        define_aggregate! {
+            XMLHttpRequest {
+                state: { value: i32 },
+                commands: { DoSomething },
+                events: { SomethingDone }
+            }
+        }
+        assert_eq!(XMLHttpRequestUrn::namespace(), "xml-http-request");
+    }
 }


### PR DESCRIPTION
- Enhanced namespace conversion algorithm to handle acronyms correctly (e.g., HTTPConnection -> http-connection instead of h-t-t-p-connection)
- Added comprehensive tests for various naming patterns including:
  * Leading acronyms (HTTPConnection)
  * Trailing acronyms (ConnectionHTTP)
  * Middle acronyms (MyHTTPServer)
  * Multiple acronyms (HTTPSAPIGateway)
  * Complex cases (XMLHttpRequest)
- Updated documentation to clarify that URN helper methods (new, parse, namespace, Display) are always generated, not just when namespace is explicitly specified
- Fixed README to reflect that namespace is auto-derived if not specified