### PR TITLE
feat: add service trait generation with async support and WASM compat…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sqlx = { version = "0.8.6", features = [
 tokio = { version = "1.49.0", features = ["full"] }
 futures = "0.3.31"
 async-stream = "0.3.6"
+async-trait = "0.1"
 
 moka = { version = "0.12.12", features = ["future"] }
 tracing = "0.1.44"

--- a/es/Cargo.toml
+++ b/es/Cargo.toml
@@ -15,6 +15,7 @@ tracing = { workspace = true }
 replay-macros = { path = "../macros" }
 tracing-test = { workspace = true }
 uuid = { workspace = true }
+async-trait = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,6 +11,7 @@ replay = { path = "../es" }
 proc-macro2 = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }
+async-trait = { workspace = true }
 
 urn = { workspace = true }
 uuid = { workspace = true }

--- a/persistence/Cargo.toml
+++ b/persistence/Cargo.toml
@@ -3,6 +3,9 @@ name = "replay-persistence"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+crate-type = ["lib", "cdylib"]
+
 [dependencies]
 replay = { path = "../es" }
 replay-macros = { path = "../macros" }

--- a/persistence/src/cqrs.rs
+++ b/persistence/src/cqrs.rs
@@ -18,7 +18,7 @@ impl<ES: EventStore> Cqrs<ES> {
         }
     }
 
-    pub async fn fetch_aggregate<A: Aggregate + Send + Sync>(
+    pub async fn fetch_aggregate<A: Aggregate + Sync>(
         &self,
         id: &A::StreamId,
         at_stream_version: Option<i64>,


### PR DESCRIPTION
…ibility

- Add service section to define_aggregate! macro for external dependencies
- Generate trait (not struct) with user-defined functions
- Support both sync and async service functions with async_trait
- Add conditional Send bounds: Send for non-WASM, ?Send for WASM targets
- Update Aggregate trait with cfg-specific variants for WASM compatibility
- Skip aggregate_macro_test from WASM compilation
- Add async_trait dependency to workspace and test crates
- Update README with async services documentation and WASM support section
- Add comprehensive examples for service trait usage