### PR TITLE
refactor!: remove serde requirement from Aggregate trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ You can chose you implement just `Stream` (state will be built from events) or `
 
 Let's assume we have a bank account with a balance that is updated when there is a deposit or withdrawal.
 
+### Serialization Requirements
+
+In this library:
+
+- **Events must be serializable** - They are persisted to the event store
+- **Aggregates don't need serde** - They are ephemeral, rebuilt from events on demand
+- This allows aggregates to contain non-serializable runtime state (streams, channels, connections, etc.)
+
 Our domain would look something like this:
 
 ```rust
@@ -25,7 +33,8 @@ use serde::{Deserialize, Serialize};
 use urn::Urn;
 
 //  bank account is an aggregate (id of aggregate is now part of the model)
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+// Note: Aggregates don't need serde - they're ephemeral and rebuilt from events
+#[derive(Clone, PartialEq, Debug)]
 struct BankAccountAggregate {
     pub id: BankAccountUrn,
     pub balance: f64,

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -324,7 +324,7 @@ pub fn define_aggregate(input: TokenStream) -> TokenStream {
 
     let expanded = quote! {
         // Aggregate state struct
-        #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Debug)]
+        #[derive(Clone, PartialEq, Debug)]
         pub struct #name {
             pub id: #urn_name,
             #(#state_fields),*

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -151,7 +151,7 @@ impl EventStore for PostgresEventStore {
                 yield Ok(row);
             }
 
-            tracing::info!("Streamed {} events from Postgres", count);
+            tracing::debug!("Streamed {} events from Postgres", count);
         }
     }
 }


### PR DESCRIPTION
Allow aggregate state to contain non-serializable types like streams and channels. Only events need serialization for persistence, while aggregates are ephemeral and reconstructed from events.

BREAKING CHANGE: Aggregate trait no longer requires Serialize + DeserializeOwned bounds. Aggregates generated by define_aggregate! macro no longer derive serde traits.

- Remove Serialize + DeserializeOwned bounds from Aggregate trait
- Remove serde derives from generated aggregate struct in define_aggregate macro
- Change postgres event streaming log level from info to debug