### PR TITLE
feat: add Compactable trait and aggregate stream compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,3 +1077,131 @@ fn build_activity_summary(events: Vec<ActivityEvent>) -> ActivitySummary {
     summary
 }
 ```
+
+## Stream Compaction
+
+As an aggregate accumulates events over a long lifetime the full history grows large, making every
+replay slower. **Compaction** lets a `Compactable` aggregate replace its live event stream with the
+minimum set of events needed to reconstruct its current state, while archiving the original history
+under a versioned snapshot.
+
+### The `Compactable` trait
+
+`compacted_events` receives the **current live event stream** from the store and returns the
+shortest subsequence that, when replayed from scratch, reproduces the same state. The aggregate
+does **not** need to store events in its own fields:
+
+```rust
+use replay::Compactable;
+
+impl Compactable for BankAccountAggregate {
+    async fn compacted_events(
+        &self,
+        events: impl TryStream<Ok = Self::Event, Error = replay::Error> + Send,
+    ) -> replay::Result<Vec<Self::Event>> {
+        use futures::TryStreamExt;
+        // Sliding-window via try_fold: only events from the last MonthlyClosed
+        // onward are kept in the accumulator. Prior months are never buffered.
+        events
+            .try_fold(Vec::new(), |mut tail, event| async move {
+                if matches!(event, BankAccountEvent::MonthlyClosed { .. }) {
+                    tail.clear();
+                }
+                tail.push(event);
+                Ok(tail)
+            })
+            .await
+    }
+}
+```
+
+### Bank-account example with `MonthlyClosed`
+
+`MonthlyClosed { month, closing_balance }` encodes an entire month's activity. Applying it sets
+the running balance directly, so the aggregate needs no extra state fields for compaction:
+
+```rust
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Event)]
+enum BankAccountEvent {
+    Deposited { operation_date: NaiveDate, amount: f64 },
+    Withdrawn { operation_date: NaiveDate, amount: f64 },
+    MonthlyClosed { month: NaiveDate, closing_balance: f64 },
+}
+
+struct BankAccountAggregate {
+    pub id: BankAccountUrn,
+    pub balance: f64,   // only what business logic needs — no compaction bookkeeping
+}
+
+impl EventStream for BankAccountAggregate {
+    type Event = BankAccountEvent;
+
+    fn stream_type() -> String { "BankAccount".to_string() }
+
+    fn apply(&mut self, event: Self::Event) {
+        match event {
+            BankAccountEvent::Deposited { amount, .. }             => self.balance += amount,
+            BankAccountEvent::Withdrawn { amount, .. }             => self.balance -= amount,
+            BankAccountEvent::MonthlyClosed { closing_balance, .. } => self.balance = closing_balance,
+        }
+    }
+}
+```
+
+**Before compaction** — 6 events in the live stream:
+
+```text
+Deposited     { operation_date: 2026-01-01, amount: 1000.00 }
+Withdrawn     { operation_date: 2026-01-15, amount:  200.00 }
+Deposited     { operation_date: 2026-01-31, amount:  500.00 }
+MonthlyClosed { month: 2026-01,  closing_balance: 1300.00  }
+Deposited     { operation_date: 2026-02-15, amount:  400.00 }
+Withdrawn     { operation_date: 2026-02-28, amount:  100.00 }
+```
+
+**After compaction** — 3 events in the live stream, 6 archived as `Version(1)`:
+
+```text
+MonthlyClosed { month: 2026-01, closing_balance: 1300.00 }   <- all of January
+Deposited     { operation_date: 2026-02-15, amount: 400.00 } <- preserved
+Withdrawn     { operation_date: 2026-02-28, amount: 100.00 } <- preserved
+```
+
+Both streams yield `balance == 1600.00`. The full history is still accessible via
+`AggregateVersion::Version(1)`.
+
+### Running compaction via `Cqrs`
+
+```rust
+// Execute commands as usual.
+cqrs.execute::<BankAccountAggregate>(
+    &stream_id, meta.clone(),
+    BankAccountCommand::CloseMonth { month: jan_1 },
+    &services, None,
+).await?;
+
+// Fetch the aggregate to pass to compact.
+let aggregate = cqrs
+    .fetch_aggregate::<BankAccountAggregate>(
+        &stream_id, AggregateVersion::Latest, None, None,
+    )
+    .await?;
+
+// Compact: archives the full history and writes the minimal live stream.
+let archive_version = cqrs.compact(&aggregate, meta).await?;
+// archive_version == 1 on the first compaction, 2 on the second, etc.
+
+// Future fetches replay only the 3 compacted events.
+let compacted = cqrs
+    .fetch_aggregate::<BankAccountAggregate>(
+        &stream_id, AggregateVersion::Latest, None, None,
+    )
+    .await?;
+
+// Original history is still accessible.
+let archived = cqrs
+    .fetch_aggregate::<BankAccountAggregate>(
+        &stream_id, AggregateVersion::Version(1), None, None,
+    )
+    .await?;
+```

--- a/README.md
+++ b/README.md
@@ -1092,6 +1092,8 @@ shortest subsequence that, when replayed from scratch, reproduces the same state
 does **not** need to store events in its own fields:
 
 ```rust
+use futures::TryStream;       // trait bound used in the signature
+use futures::TryStreamExt;    // .try_fold() extension method
 use replay::Compactable;
 
 impl Compactable for BankAccountAggregate {
@@ -1099,7 +1101,6 @@ impl Compactable for BankAccountAggregate {
         &self,
         events: impl TryStream<Ok = Self::Event, Error = replay::Error> + Send,
     ) -> replay::Result<Vec<Self::Event>> {
-        use futures::TryStreamExt;
         // Sliding-window via try_fold: only events from the last MonthlyClosed
         // onward are kept in the accumulator. Prior months are never buffered.
         events

--- a/es/Cargo.toml
+++ b/es/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = { workspace = true }
 urn = { workspace = true }
 
 tracing = { workspace = true }
+futures = { workspace = true }
 
 [dev-dependencies]
 replay-macros = { path = "../macros" }

--- a/es/src/aggregate.rs
+++ b/es/src/aggregate.rs
@@ -117,7 +117,7 @@ pub trait Aggregate: Sync + EventStream {
 ///
 /// The original history is **not** discarded by this trait — it is the caller's responsibility
 /// to archive or retain old events before replacing them with the compacted set.
-/// [`EventStore::compact`] handles this automatically: it archives the full event log under a
+/// The store's `compact` operation handles this automatically: it archives the full event log under a
 /// numbered version before writing the compacted set as the new live stream.
 ///
 /// # Implementation contract

--- a/es/src/aggregate.rs
+++ b/es/src/aggregate.rs
@@ -122,12 +122,12 @@ pub trait Aggregate: Sync + EventStream {
 ///
 /// # Implementation contract
 ///
-/// `compacted_events` must derive its output solely from the aggregate's **current in-memory
-/// state fields** — never from a stored log. This guarantees that redundant or cancelling events
-/// are naturally omitted: only what the state actually contains ends up in the result.
+/// `compacted_events` receives the **current live event stream** supplied by the store and must
+/// return the shortest subsequence that, when replayed from a freshly constructed aggregate
+/// (via `with_id`), reproduces the identical state observable before compaction.
 ///
-/// The returned sequence must be self-sufficient: replaying it against a freshly constructed
-/// aggregate (via `with_id`) must reproduce the identical state observable before compaction.
+/// Implementations should process the stream lazily — buffering only the events that are truly
+/// needed in the output — rather than collecting the full history into memory first.
 ///
 /// # Monthly bank-account compaction example
 ///

--- a/es/src/aggregate.rs
+++ b/es/src/aggregate.rs
@@ -1,5 +1,7 @@
 use std::future::Future;
 
+use futures::TryStream;
+
 use crate::{Error, EventStream};
 
 /// An aggregate is a domain-driven design pattern that allows you to model a domain entity as a sequence of events.
@@ -103,6 +105,162 @@ pub trait Aggregate: Sync + EventStream {
             Ok(events)
         }
     }
+}
+
+/// A trait for aggregates that can produce the minimum set of events needed to reconstruct
+/// their current state, discarding redundant or superseded events from the full history.
+///
+/// In event sourcing, an aggregate's full event history may contain events that cancel each other
+/// out (e.g. `Add("a")` followed by `Delete("a")`). Storing and replaying all of them is
+/// correct but inefficient. `Compactable` lets an aggregate express the *minimal* event sequence
+/// that, when replayed from a clean state, would produce the same current state.
+///
+/// The original history is **not** discarded by this trait — it is the caller's responsibility
+/// to archive or retain old events before replacing them with the compacted set.
+/// [`EventStore::compact`] handles this automatically: it archives the full event log under a
+/// numbered version before writing the compacted set as the new live stream.
+///
+/// # Implementation contract
+///
+/// `compacted_events` must derive its output solely from the aggregate's **current in-memory
+/// state fields** — never from a stored log. This guarantees that redundant or cancelling events
+/// are naturally omitted: only what the state actually contains ends up in the result.
+///
+/// The returned sequence must be self-sufficient: replaying it against a freshly constructed
+/// aggregate (via `with_id`) must reproduce the identical state observable before compaction.
+///
+/// # Monthly bank-account compaction example
+///
+/// ## The problem
+///
+/// A busy bank account accumulates thousands of `Deposited` and `Withdrawn` events over many
+/// months. Replaying the full stream on every command grows increasingly slow. However, individual
+/// transactions within the *current* period must remain queryable (e.g. for a monthly statement),
+/// so they cannot simply be dropped.
+///
+/// ## The strategy
+///
+/// Introduce a single summary event:
+///
+/// - **`MonthlyClosed`** — recorded when a month ends; carries the month and its closing balance.
+///   Applying it sets the running balance directly, replacing the entire transaction history of
+///   all prior months.
+///
+/// When `compact` is called:
+///
+/// 1. All history is archived under a new version number (handled by the store).
+/// 2. The store passes the current live event stream to `compacted_events`.
+/// 3. The live stream is replaced with the minimal sequence returned by `compacted_events`:
+///    - The last `MonthlyClosed` event (encodes the entire prior history).
+///    - Any individual `Deposited` / `Withdrawn` events recorded **after** it.
+///
+/// Replaying these few events is enough to reconstruct the exact same aggregate state.
+/// The full history is still accessible via `AggregateVersion::Version(n)`.
+///
+/// ## Code
+///
+/// ```rust,ignore
+/// use chrono::NaiveDate;
+/// use serde::{Deserialize, Serialize};
+/// use replay::{Compactable, EventStream, WithId};
+/// use replay_macros::Event;
+///
+/// // ── Events ──────────────────────────────────────────────────────────────
+///
+/// #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Event)]
+/// enum BankAccountEvent {
+///     /// A positive amount was credited to the account.
+///     Deposited { operation_date: NaiveDate, amount: f64 },
+///     /// A positive amount was debited from the account.
+///     Withdrawn { operation_date: NaiveDate, amount: f64 },
+///     /// Marks the end of a calendar month and records the closing balance.
+///     /// Applying this event restores the balance without replaying prior transactions.
+///     MonthlyClosed { month: NaiveDate, closing_balance: f64 },
+/// }
+///
+/// // ── Aggregate ────────────────────────────────────────────────────────────
+/// // No extra state fields needed — the aggregate only tracks what it needs for
+/// // business logic.  Compaction is driven by the event stream itself.
+///
+/// struct BankAccountAggregate {
+///     pub id: BankAccountUrn,
+///     pub balance: f64,
+/// }
+///
+/// // ── EventStream ──────────────────────────────────────────────────────────
+///
+/// impl EventStream for BankAccountAggregate {
+///     type Event = BankAccountEvent;
+///
+///     fn stream_type() -> String { "BankAccount".to_string() }
+///
+///     fn apply(&mut self, event: Self::Event) {
+///         match event {
+///             BankAccountEvent::Deposited { amount, .. }  => self.balance += amount,
+///             BankAccountEvent::Withdrawn { amount, .. }  => self.balance -= amount,
+///             BankAccountEvent::MonthlyClosed { closing_balance, .. } => {
+///                 self.balance = closing_balance;
+///             }
+///         }
+///     }
+/// }
+///
+/// // ── Compactable ──────────────────────────────────────────────────────────
+///
+/// impl Compactable for BankAccountAggregate {
+///     async fn compacted_events(
+///         &self,
+///         events: impl TryStream<Ok = Self::Event, Error = replay::Error> + Send,
+///     ) -> replay::Result<Vec<Self::Event>> {
+///         use futures::TryStreamExt;
+///         // Sliding-window via try_fold: only keep events from the last
+///         // MonthlyClosed onward.  Prior months are never buffered in memory.
+///         events
+///             .try_fold(Vec::new(), |mut tail, event| async move {
+///                 if matches!(event, BankAccountEvent::MonthlyClosed { .. }) {
+///                     tail.clear(); // discard all history before this checkpoint
+///                 }
+///                 tail.push(event);
+///                 Ok(tail)
+///             })
+///             .await
+///     }
+/// }
+/// ```
+///
+/// ## Before and after compaction
+///
+/// **Full history (stored as `Version(1)` after the first compact call):**
+/// ```text
+/// Deposited    { operation_date: 2026-01-01, amount: 1000.00 }
+/// Withdrawn    { operation_date: 2026-01-15, amount:  200.00 }
+/// Deposited    { operation_date: 2026-01-31, amount:  500.00 }
+/// MonthlyClosed { month: 2026-01, closing_balance: 1300.00 }
+/// Deposited    { operation_date: 2026-02-15, amount:  400.00 }  ← current period
+/// Withdrawn    { operation_date: 2026-02-28, amount:  100.00 }  ← current period
+/// ```
+///
+/// **Compacted live stream (3 events instead of 6):**
+/// ```text
+/// MonthlyClosed { month: 2026-01, closing_balance: 1300.00 }  ← all of January
+/// Deposited    { operation_date: 2026-02-15, amount: 400.00 } ← preserved
+/// Withdrawn    { operation_date: 2026-02-28, amount: 100.00 } ← preserved
+/// ```
+///
+/// Replaying the compacted stream yields `balance == 1600.00`, identical to replaying
+/// the full history. The full history remains accessible via `AggregateVersion::Version(1)`.
+pub trait Compactable: EventStream {
+    /// Consumes the current live event stream for this aggregate and returns the minimal
+    /// subsequence that, when replayed from a fresh instance, reproduces the current state.
+    ///
+    /// The store passes the live stream to this method so implementations can process events
+    /// one at a time without loading the entire history into memory.  Only events that must
+    /// be preserved (e.g. the most recent summary + the current-period transactions) need to
+    /// be buffered.
+    fn compacted_events(
+        &self,
+        events: impl TryStream<Ok = Self::Event, Error = Error> + Send,
+    ) -> impl Future<Output = crate::Result<Vec<Self::Event>>> + Send;
 }
 
 // tests

--- a/es/src/lib.rs
+++ b/es/src/lib.rs
@@ -4,7 +4,7 @@ mod event;
 mod metadata;
 mod stream;
 
-pub use aggregate::Aggregate;
+pub use aggregate::{Aggregate, Compactable};
 pub use error::{Error, ErrorKind, ErrorStatus, Result};
 pub use event::Event;
 pub use metadata::Metadata;

--- a/persistence/src/aggregate_version.rs
+++ b/persistence/src/aggregate_version.rs
@@ -1,0 +1,29 @@
+/// Identifies which version of an aggregate's event stream to load.
+///
+/// In event sourcing, compaction archives the full event log under a numbered version
+/// and replaces it with a minimal set of events that reproduce the same state.
+/// `AggregateVersion` lets callers choose whether to replay the current (compacted)
+/// events or to inspect a specific archived version.
+///
+/// # Variants
+/// - `Latest` — load the current event stream (default, no version filter).
+/// - `Version(u32)` — load the archived event stream created by a specific compaction run.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum AggregateVersion {
+    /// Load the current event stream (post-compaction or uncompacted).
+    #[default]
+    Latest,
+    /// Load the archived event stream produced by the nth compaction.
+    Version(u32),
+}
+
+impl AggregateVersion {
+    /// Returns `None` for `Latest` (stored as SQL NULL / no version tag)
+    /// and `Some(n)` for `Version(n)`.
+    pub fn as_option(&self) -> Option<u32> {
+        match self {
+            AggregateVersion::Latest => None,
+            AggregateVersion::Version(v) => Some(*v),
+        }
+    }
+}

--- a/persistence/src/aggregate_version.rs
+++ b/persistence/src/aggregate_version.rs
@@ -7,20 +7,21 @@
 ///
 /// # Variants
 /// - `Latest` — load the current event stream (default, no version filter).
-/// - `Version(u32)` — load the archived event stream created by a specific compaction run.
+/// - `Version(i32)` — load the archived event stream created by a specific compaction run.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum AggregateVersion {
     /// Load the current event stream (post-compaction or uncompacted).
     #[default]
     Latest,
     /// Load the archived event stream produced by the nth compaction.
-    Version(u32),
+    /// Matches the `INTEGER` column in the database; values start at 1 and increment.
+    Version(i32),
 }
 
 impl AggregateVersion {
     /// Returns `None` for `Latest` (stored as SQL NULL / no version tag)
     /// and `Some(n)` for `Version(n)`.
-    pub fn as_option(&self) -> Option<u32> {
+    pub fn as_option(&self) -> Option<i32> {
         match self {
             AggregateVersion::Latest => None,
             AggregateVersion::Version(v) => Some(*v),

--- a/persistence/src/cqrs.rs
+++ b/persistence/src/cqrs.rs
@@ -4,7 +4,7 @@ use futures::{StreamExt, TryStreamExt};
 
 use replay::{Aggregate, Event};
 
-use super::EventStore;
+use super::{AggregateVersion, EventStore};
 
 #[derive(Clone)]
 pub struct Cqrs<ES: EventStore> {
@@ -18,15 +18,23 @@ impl<ES: EventStore> Cqrs<ES> {
         }
     }
 
+    /// Reconstruct an aggregate from its persisted event stream.
+    ///
+    /// - `aggregate_version`: choose which snapshot of the stream to load.  Use
+    ///   [`AggregateVersion::Latest`] (the default) to replay the current event stream; use
+    ///   [`AggregateVersion::Version(n)`] to inspect a specific archived compaction version.
+    /// - `at_stream_version`: optional upper bound on the event sequence number.
+    /// - `at_timestamp`: optional upper bound on the event creation timestamp.
     pub async fn fetch_aggregate<A: Aggregate + Sync>(
         &self,
         id: &A::StreamId,
+        aggregate_version: AggregateVersion,
         at_stream_version: Option<i64>,
         at_timestamp: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<A, A::Error> {
         let events = self
             .store
-            .stream_events_by_stream_id::<A>(id, at_stream_version, at_timestamp)
+            .stream_events_by_stream_id::<A>(id, aggregate_version, at_stream_version, at_timestamp)
             .map_err(A::Error::from);
 
         let mut stream = A::with_id(id.clone());
@@ -48,9 +56,9 @@ impl<ES: EventStore> Cqrs<ES> {
         services: &A::Services,
         expected_version: Option<i64>,
     ) -> Result<A, A::Error> {
-        // get stream from store
+        // Always load the latest (current) event stream for command handling.
         let mut aggregate = self
-            .fetch_aggregate::<A>(id, expected_version, None)
+            .fetch_aggregate::<A>(id, AggregateVersion::Latest, expected_version, None)
             .await?;
 
         let stream_type = A::stream_type();
@@ -65,6 +73,25 @@ impl<ES: EventStore> Cqrs<ES> {
         aggregate.apply_all(events);
 
         Ok(aggregate)
+    }
+
+    /// Compact the event stream for an aggregate.
+    ///
+    /// Archives the current full history under a new version number, then replaces
+    /// the live stream with the minimal set of events returned by
+    /// [`Compactable::compacted_events`].  Returns the archive version number that
+    /// was created (starting at `1` for the first compaction).
+    ///
+    /// See [`EventStore::compact`] for the full description of the algorithm.
+    pub async fn compact<A>(
+        &self,
+        aggregate: &A,
+        metadata: replay::Metadata,
+    ) -> Result<u32, replay::Error>
+    where
+        A: replay::Aggregate + replay::Compactable + Sync,
+    {
+        self.store.compact(aggregate, metadata).await
     }
 
     pub async fn run_query<'a, Q, E>(&'a self, query: &'a mut Q) -> Result<(), replay::Error>

--- a/persistence/src/cqrs.rs
+++ b/persistence/src/cqrs.rs
@@ -87,7 +87,7 @@ impl<ES: EventStore> Cqrs<ES> {
         &self,
         aggregate: &A,
         metadata: replay::Metadata,
-    ) -> Result<u32, replay::Error>
+    ) -> Result<i32, replay::Error>
     where
         A: replay::Aggregate + replay::Compactable + Sync,
     {

--- a/persistence/src/cqrs.rs
+++ b/persistence/src/cqrs.rs
@@ -23,8 +23,10 @@ impl<ES: EventStore> Cqrs<ES> {
     /// - `aggregate_version`: choose which snapshot of the stream to load.  Use
     ///   [`AggregateVersion::Latest`] (the default) to replay the current event stream; use
     ///   [`AggregateVersion::Version(n)`] to inspect a specific archived compaction version.
-    /// - `at_stream_version`: optional upper bound on the event sequence number.
-    /// - `at_timestamp`: optional upper bound on the event creation timestamp.
+    /// - `at_stream_version`: optional inclusive upper bound on the event sequence number
+    ///   (events with version ≤ n are included).  Use this for time-travel reads.
+    /// - `at_timestamp`: optional inclusive upper bound on the event creation timestamp
+    ///   (events created at or before the given instant are included).
     pub async fn fetch_aggregate<A: Aggregate + Sync>(
         &self,
         id: &A::StreamId,

--- a/persistence/src/filters.rs
+++ b/persistence/src/filters.rs
@@ -17,7 +17,7 @@ pub enum StreamFilter {
     CreatedAfter(chrono::DateTime<Utc>),
     /// Matches events whose `aggregate_version` equals the given value.
     /// `None` selects current (non-archived) events; `Some(n)` selects version n.
-    WithAggregateVersion(Option<u32>),
+    WithAggregateVersion(Option<i32>),
     And(Box<StreamFilter>, Box<StreamFilter>),
     Or(Box<StreamFilter>, Box<StreamFilter>),
     Not(Box<StreamFilter>),
@@ -101,11 +101,11 @@ impl StreamFilter {
         }
     }
 
-    pub fn with_aggregate_version(aggregate_version: Option<u32>) -> StreamFilter {
+    pub fn with_aggregate_version(aggregate_version: Option<i32>) -> StreamFilter {
         StreamFilter::WithAggregateVersion(aggregate_version)
     }
 
-    pub fn and_aggregate_version(self, aggregate_version: Option<u32>) -> StreamFilter {
+    pub fn and_aggregate_version(self, aggregate_version: Option<i32>) -> StreamFilter {
         self.and(StreamFilter::WithAggregateVersion(aggregate_version))
     }
 }

--- a/persistence/src/filters.rs
+++ b/persistence/src/filters.rs
@@ -15,6 +15,9 @@ pub enum StreamFilter {
     WithMetadata(replay::Metadata),
     AfterVersion(i64),
     CreatedAfter(chrono::DateTime<Utc>),
+    /// Matches events whose `aggregate_version` equals the given value.
+    /// `None` selects current (non-archived) events; `Some(n)` selects version n.
+    WithAggregateVersion(Option<u32>),
     And(Box<StreamFilter>, Box<StreamFilter>),
     Or(Box<StreamFilter>, Box<StreamFilter>),
     Not(Box<StreamFilter>),
@@ -29,6 +32,7 @@ impl StreamFilter {
             StreamFilter::WithMetadata(metadata) => event.metadata == *metadata,
             StreamFilter::AfterVersion(version) => event.version > *version,
             StreamFilter::CreatedAfter(timestamp) => event.created > *timestamp,
+            StreamFilter::WithAggregateVersion(v) => event.aggregate_version == *v,
             StreamFilter::And(left, right) => left.passes::<S>(event) && right.passes::<S>(event),
             StreamFilter::Or(left, right) => left.passes::<S>(event) || right.passes::<S>(event),
             StreamFilter::Not(filter) => !filter.passes::<S>(event),
@@ -95,6 +99,14 @@ impl StreamFilter {
             Some(timestamp) => self.and(StreamFilter::CreatedAfter(timestamp)),
             None => self,
         }
+    }
+
+    pub fn with_aggregate_version(aggregate_version: Option<u32>) -> StreamFilter {
+        StreamFilter::WithAggregateVersion(aggregate_version)
+    }
+
+    pub fn and_aggregate_version(self, aggregate_version: Option<u32>) -> StreamFilter {
+        self.and(StreamFilter::WithAggregateVersion(aggregate_version))
     }
 }
 
@@ -209,6 +221,7 @@ mod tests {
                 bank_account: bank_account_urn,
             }
             .into(),
+            aggregate_version: None,
         };
         assert!(filter.passes::<BankAccountStream>(&persisted_event));
     }
@@ -232,6 +245,7 @@ mod tests {
                 bank_account: bank_account_urn,
             }
             .into(),
+            aggregate_version: None,
         };
         assert!(filter.passes::<BankAccountStream>(&persisted_event));
     }
@@ -255,6 +269,7 @@ mod tests {
                 bank_account: bank_account_urn,
             }
             .into(),
+            aggregate_version: None,
         };
         assert!(filter.passes::<BankAccountStream>(&persisted_event));
     }
@@ -276,6 +291,7 @@ mod tests {
             version: 1,
             created: chrono::Utc::now(),
             metadata: metadata.into(),
+            aggregate_version: None,
         };
         assert!(filter.passes::<BankAccountStream>(&persisted_event));
     }
@@ -299,6 +315,7 @@ mod tests {
                 bank_account: bank_account_urn,
             }
             .into(),
+            aggregate_version: None,
         };
         assert!(filter.passes::<BankAccountStream>(&persisted_event));
     }
@@ -323,6 +340,7 @@ mod tests {
                 bank_account: bank_account_urn,
             }
             .into(),
+            aggregate_version: None,
         };
         assert!(filter.passes::<BankAccountStream>(&persisted_event));
     }
@@ -347,6 +365,7 @@ mod tests {
                 bank_account: bank_account_urn,
             }
             .into(),
+            aggregate_version: None,
         };
         assert!(filter.passes::<BankAccountStream>(&persisted_event));
     }
@@ -371,6 +390,7 @@ mod tests {
                 bank_account: bank_account_urn,
             }
             .into(),
+            aggregate_version: None,
         };
         assert!(filter.passes::<BankAccountStream>(&persisted_event));
     }
@@ -395,6 +415,7 @@ mod tests {
                 bank_account: bank_account_urn,
             }
             .into(),
+            aggregate_version: None,
         };
 
         assert!(filter.passes::<BankAccountStream>(&persisted_event));

--- a/persistence/src/filters.rs
+++ b/persistence/src/filters.rs
@@ -13,8 +13,14 @@ pub enum StreamFilter {
     WithStreamId(Urn),
     ForStreamTypes(Vec<String>),
     WithMetadata(replay::Metadata),
+    /// Matches events whose sequence version is strictly greater than the given value.
     AfterVersion(i64),
+    /// Matches events whose sequence version is less than or equal to the given value.
+    UpToVersion(i64),
+    /// Matches events created strictly after the given timestamp.
     CreatedAfter(chrono::DateTime<Utc>),
+    /// Matches events created at or before the given timestamp.
+    CreatedBefore(chrono::DateTime<Utc>),
     /// Matches events whose `aggregate_version` equals the given value.
     /// `None` selects current (non-archived) events; `Some(n)` selects version n.
     WithAggregateVersion(Option<i32>),
@@ -31,7 +37,9 @@ impl StreamFilter {
             StreamFilter::ForStreamTypes(stream_types) => stream_types.contains(&S::stream_type()),
             StreamFilter::WithMetadata(metadata) => event.metadata == *metadata,
             StreamFilter::AfterVersion(version) => event.version > *version,
+            StreamFilter::UpToVersion(version) => event.version <= *version,
             StreamFilter::CreatedAfter(timestamp) => event.created > *timestamp,
+            StreamFilter::CreatedBefore(timestamp) => event.created <= *timestamp,
             StreamFilter::WithAggregateVersion(v) => event.aggregate_version == *v,
             StreamFilter::And(left, right) => left.passes::<S>(event) && right.passes::<S>(event),
             StreamFilter::Or(left, right) => left.passes::<S>(event) || right.passes::<S>(event),
@@ -59,8 +67,16 @@ impl StreamFilter {
         StreamFilter::AfterVersion(version)
     }
 
+    pub fn up_to_version(version: i64) -> StreamFilter {
+        StreamFilter::UpToVersion(version)
+    }
+
     pub fn created_after(timestamp: chrono::DateTime<Utc>) -> StreamFilter {
         StreamFilter::CreatedAfter(timestamp)
+    }
+
+    pub fn created_before(timestamp: chrono::DateTime<Utc>) -> StreamFilter {
+        StreamFilter::CreatedBefore(timestamp)
     }
 
     // implement methods from an existing filter
@@ -76,19 +92,22 @@ impl StreamFilter {
         self.and(StreamFilter::with_metadata(metadata))
     }
 
+    /// Filter to events with sequence version ≤ `version` (inclusive upper bound, for time-travel reads).
     pub fn and_at_stream_version(self, version: i64) -> StreamFilter {
-        self.and(StreamFilter::AfterVersion(version))
+        self.and(StreamFilter::UpToVersion(version))
     }
 
+    /// Filter to events with sequence version ≤ `version` when `Some`, otherwise no-op.
     pub fn and_at_stream_version_optional(self, version: Option<i64>) -> StreamFilter {
         match version {
-            Some(version) => self.and(StreamFilter::AfterVersion(version)),
+            Some(version) => self.and(StreamFilter::UpToVersion(version)),
             None => self,
         }
     }
 
+    /// Filter to events created at or before `timestamp` (inclusive upper bound, for time-travel reads).
     pub fn and_at_timestamp(self, timestamp: chrono::DateTime<Utc>) -> StreamFilter {
-        self.and(StreamFilter::CreatedAfter(timestamp))
+        self.and(StreamFilter::CreatedBefore(timestamp))
     }
 
     pub fn and_at_timestamp_optional(
@@ -96,7 +115,7 @@ impl StreamFilter {
         timestamp: Option<chrono::DateTime<Utc>>,
     ) -> StreamFilter {
         match timestamp {
-            Some(timestamp) => self.and(StreamFilter::CreatedAfter(timestamp)),
+            Some(timestamp) => self.and(StreamFilter::CreatedBefore(timestamp)),
             None => self,
         }
     }

--- a/persistence/src/infrastructure/in_memory_store.rs
+++ b/persistence/src/infrastructure/in_memory_store.rs
@@ -93,8 +93,7 @@ impl EventStore for InMemoryEventStore {
             .map(|events| {
                 events
                     .iter()
-                    .filter(|e| e.aggregate_version.is_none())
-                    .last()
+                    .rfind(|e| e.aggregate_version.is_none())
                     .map(|e| e.version)
                     .unwrap_or(0)
             })
@@ -179,7 +178,7 @@ impl EventStore for InMemoryEventStore {
         &self,
         aggregate: &A,
         metadata: replay::Metadata,
-    ) -> Result<u32, replay::Error>
+    ) -> Result<i32, replay::Error>
     where
         A: replay::Aggregate + Compactable + Sync,
     {
@@ -212,7 +211,7 @@ impl EventStore for InMemoryEventStore {
             let mut store = self.events.write().unwrap();
             let stream = store.entry(stream_id.clone()).or_default();
 
-            let next_version: u32 = stream
+            let next_version: i32 = stream
                 .iter()
                 .filter_map(|e| e.aggregate_version)
                 .max()
@@ -228,9 +227,8 @@ impl EventStore for InMemoryEventStore {
 
             // Insert compacted events as the new current stream (aggregate_version = None).
             // Sequence versions restart from 1.
-            let mut seq: i64 = 0;
-            for event in &compacted {
-                seq += 1;
+            for (seq, event) in (0_i64..).zip(compacted.iter()) {
+                let seq = seq + 1;
                 let data = serde_json::to_value(event).map_err(crate::ser_error)?;
                 stream.push(PersistedEvent {
                     id: Uuid::new_v4(),
@@ -244,7 +242,7 @@ impl EventStore for InMemoryEventStore {
                 });
             }
 
-            return Ok(next_version);
+            Ok(next_version)
         }
     }
 }

--- a/persistence/src/infrastructure/in_memory_store.rs
+++ b/persistence/src/infrastructure/in_memory_store.rs
@@ -56,7 +56,9 @@ impl InMemoryEventStore {
             .with_operation("stream_events")),
             StreamFilter::WithMetadata(metadata) => Ok(event.metadata == *metadata),
             StreamFilter::AfterVersion(version) => Ok(event.version > *version),
+            StreamFilter::UpToVersion(version) => Ok(event.version <= *version),
             StreamFilter::CreatedAfter(timestamp) => Ok(event.created > *timestamp),
+            StreamFilter::CreatedBefore(timestamp) => Ok(event.created <= *timestamp),
             StreamFilter::WithAggregateVersion(v) => Ok(event.aggregate_version == *v),
             StreamFilter::And(left, right) => {
                 Ok(Self::evaluate(left, event)? && Self::evaluate(right, event)?)

--- a/persistence/src/infrastructure/in_memory_store.rs
+++ b/persistence/src/infrastructure/in_memory_store.rs
@@ -211,6 +211,13 @@ impl EventStore for InMemoryEventStore {
         // 2. Determine the next archive version number and archive all current events.
         {
             let mut store = self.events.write().unwrap();
+
+            if !store.contains_key(&stream_id) {
+                return Err(replay::Error::not_found("Stream not found")
+                    .with_operation("compact")
+                    .with_context("stream_id", stream_id.to_string()));
+            }
+
             let stream = store.entry(stream_id.clone()).or_default();
 
             let next_version: i32 = stream
@@ -526,17 +533,13 @@ mod tests {
 
         let account = BankAccountStream::with_id(id.clone());
 
-        // Compacting a stream with no prior events should succeed.
-        let archive_version = store
-            .compact(&account, replay::Metadata::default())
-            .await
-            .unwrap();
+        // Compacting a stream that has never had events should return NotFound,
+        // matching the behaviour of PostgresEventStore::compact.
+        let result = store.compact(&account, replay::Metadata::default()).await;
 
-        assert_eq!(archive_version, 1);
-
-        // The compacted set for balance=0 is [Deposited(0)]; live stream has that one event.
-        let live = live_events(&store, &id).await;
-        assert_eq!(live, vec![BankAccountEvent::Deposited { amount: 0.0 }]);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), replay::ErrorKind::NotFound);
     }
 
     #[tokio::test]

--- a/persistence/src/infrastructure/in_memory_store.rs
+++ b/persistence/src/infrastructure/in_memory_store.rs
@@ -326,6 +326,217 @@ mod tests {
         }
     }
 
+    // ── Compactable support ──────────────────────────────────────────────────
+
+    /// A compaction strategy that collapses the whole history into a single
+    /// `Deposited` event whose amount equals the current balance.
+    impl Compactable for BankAccountStream {
+        async fn compacted_events(
+            &self,
+            events: impl futures::TryStream<Ok = Self::Event, Error = replay::Error> + Send,
+        ) -> replay::Result<Vec<Self::Event>> {
+            use futures::TryStreamExt;
+            let all: Vec<BankAccountEvent> = events.try_collect().await?;
+            let balance = all.iter().fold(0.0_f64, |acc, ev| match ev {
+                BankAccountEvent::Deposited { amount } => acc + amount,
+                BankAccountEvent::Withdrawn { amount } => acc - amount,
+            });
+            Ok(vec![BankAccountEvent::Deposited { amount: balance }])
+        }
+    }
+
+    impl replay::Aggregate for BankAccountStream {
+        type Command = ();
+        type Error = replay::Error;
+        type Services = ();
+
+        async fn handle(
+            &self,
+            _command: Self::Command,
+            _services: &Self::Services,
+        ) -> replay::Result<Vec<Self::Event>> {
+            Ok(vec![])
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    fn make_stream_id(n: &str) -> BankAccountUrn {
+        BankAccountUrn(UrnBuilder::new("bank-account", n).build().unwrap())
+    }
+
+    async fn add_events(
+        store: &InMemoryEventStore,
+        id: &BankAccountUrn,
+        events: &[BankAccountEvent],
+    ) {
+        store
+            .store_events::<BankAccountStream>(
+                id,
+                "BankAccount".to_string(),
+                replay::Metadata::default(),
+                events,
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn live_events(store: &InMemoryEventStore, id: &BankAccountUrn) -> Vec<BankAccountEvent> {
+        use futures::TryStreamExt;
+        store
+            .stream_events::<BankAccountEvent>(StreamFilter::And(
+                Box::new(StreamFilter::with_stream_id::<BankAccountStream>(id)),
+                Box::new(StreamFilter::WithAggregateVersion(None)),
+            ))
+            .map_ok(|e| e.data)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+    }
+
+    async fn archived_events(
+        store: &InMemoryEventStore,
+        id: &BankAccountUrn,
+        version: i32,
+    ) -> Vec<PersistedEvent<BankAccountEvent>> {
+        use futures::TryStreamExt;
+        store
+            .stream_events::<BankAccountEvent>(StreamFilter::And(
+                Box::new(StreamFilter::with_stream_id::<BankAccountStream>(id)),
+                Box::new(StreamFilter::WithAggregateVersion(Some(version))),
+            ))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+    }
+
+    // ── compact tests ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_compact_reduces_live_events() {
+        let store = InMemoryEventStore::new();
+        let id = make_stream_id("compact-1");
+
+        add_events(
+            &store,
+            &id,
+            &[
+                BankAccountEvent::Deposited { amount: 100.0 },
+                BankAccountEvent::Withdrawn { amount: 40.0 },
+                BankAccountEvent::Deposited { amount: 50.0 },
+            ],
+        )
+        .await;
+
+        // Build the aggregate state so `compacted_events` has the right `self`.
+        let mut account = BankAccountStream::with_id(id.clone());
+        for ev in live_events(&store, &id).await {
+            account.apply(ev);
+        }
+        assert_eq!(account.balance, 110.0);
+
+        let archive_version = store
+            .compact(&account, replay::Metadata::default())
+            .await
+            .unwrap();
+
+        assert_eq!(archive_version, 1);
+
+        // Live stream is now a single synthetic Deposited event.
+        let live = live_events(&store, &id).await;
+        assert_eq!(live, vec![BankAccountEvent::Deposited { amount: 110.0 }]);
+
+        // Original 3 events are archived under version 1.
+        let archived = archived_events(&store, &id, 1).await;
+        assert_eq!(archived.len(), 3);
+        assert!(archived.iter().all(|e| e.aggregate_version == Some(1)));
+    }
+
+    #[tokio::test]
+    async fn test_compact_increments_archive_version() {
+        let store = InMemoryEventStore::new();
+        let id = make_stream_id("compact-2");
+
+        add_events(
+            &store,
+            &id,
+            &[
+                BankAccountEvent::Deposited { amount: 200.0 },
+                BankAccountEvent::Withdrawn { amount: 50.0 },
+            ],
+        )
+        .await;
+
+        let mut account = BankAccountStream::with_id(id.clone());
+        for ev in live_events(&store, &id).await {
+            account.apply(ev);
+        }
+
+        // First compaction → archive version 1, live = [Deposited(150)].
+        store
+            .compact(&account, replay::Metadata::default())
+            .await
+            .unwrap();
+
+        // Add more events after the first compaction.
+        store
+            .store_events::<BankAccountStream>(
+                &id,
+                "BankAccount".to_string(),
+                replay::Metadata::default(),
+                &[BankAccountEvent::Withdrawn { amount: 30.0 }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Rebuild aggregate for second compaction.
+        let mut account2 = BankAccountStream::with_id(id.clone());
+        for ev in live_events(&store, &id).await {
+            account2.apply(ev);
+        }
+        assert_eq!(account2.balance, 120.0);
+
+        let archive_version2 = store
+            .compact(&account2, replay::Metadata::default())
+            .await
+            .unwrap();
+
+        assert_eq!(archive_version2, 2);
+
+        let live = live_events(&store, &id).await;
+        assert_eq!(live, vec![BankAccountEvent::Deposited { amount: 120.0 }]);
+
+        // Version 1 archive still intact (2 original events).
+        let arch1 = archived_events(&store, &id, 1).await;
+        assert_eq!(arch1.len(), 2);
+
+        // Version 2 archive contains the compacted event + the post-compaction withdrawal.
+        let arch2 = archived_events(&store, &id, 2).await;
+        assert_eq!(arch2.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_compact_empty_stream_is_noop() {
+        let store = InMemoryEventStore::new();
+        let id = make_stream_id("compact-empty");
+
+        let account = BankAccountStream::with_id(id.clone());
+
+        // Compacting a stream with no prior events should succeed.
+        let archive_version = store
+            .compact(&account, replay::Metadata::default())
+            .await
+            .unwrap();
+
+        assert_eq!(archive_version, 1);
+
+        // The compacted set for balance=0 is [Deposited(0)]; live stream has that one event.
+        let live = live_events(&store, &id).await;
+        assert_eq!(live, vec![BankAccountEvent::Deposited { amount: 0.0 }]);
+    }
+
     #[tokio::test]
     async fn test_store_events() {
         let store = InMemoryEventStore {

--- a/persistence/src/infrastructure/in_memory_store.rs
+++ b/persistence/src/infrastructure/in_memory_store.rs
@@ -7,15 +7,72 @@ use urn::Urn;
 use uuid::Uuid;
 
 use crate::{EventStore, PersistedEvent, StreamFilter};
-use replay::Event;
+use replay::{Compactable, Event};
 
 /// In-memory event store implementation, only for testing purpose.
 ///
-/// It ignores stream type and metadata.
+/// It ignores stream type.
 ///
-/// It only supports filter by stream id.
+/// Events are stored per-stream-URN in insertion order. The `aggregate_version` field on each
+/// event distinguishes current events (`None`) from archived compaction snapshots (`Some(n)`).
 pub struct InMemoryEventStore {
     events: RwLock<HashMap<Urn, Vec<PersistedEvent<Value>>>>,
+}
+
+impl InMemoryEventStore {
+    pub fn new() -> Self {
+        Self {
+            events: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Walk a filter tree and return the first `WithStreamId` URN found (used for fast lookup).
+    fn extract_stream_id(filter: &StreamFilter) -> Option<Urn> {
+        match filter {
+            StreamFilter::WithStreamId(id) => Some(id.clone()),
+            StreamFilter::And(left, right) => {
+                Self::extract_stream_id(left).or_else(|| Self::extract_stream_id(right))
+            }
+            _ => None,
+        }
+    }
+
+    /// Apply a filter to a raw (un-typed) persisted event.
+    ///
+    /// Returns an error if the filter contains a `ForStreamTypes` variant — that variant
+    /// requires knowledge of the concrete `EventStream` type at compile time, which is not
+    /// available when working with the raw JSON storage of the in-memory store.
+    fn evaluate<E>(
+        filter: &StreamFilter,
+        event: &PersistedEvent<E>,
+    ) -> Result<bool, replay::Error> {
+        match filter {
+            StreamFilter::All => Ok(true),
+            StreamFilter::WithStreamId(stream_id) => Ok(event.stream_id == *stream_id),
+            StreamFilter::ForStreamTypes(_) => Err(replay::Error::internal(
+                "InMemoryEventStore does not support ForStreamTypes filters; \
+                 use stream_events_by_stream_id with a concrete EventStream type instead",
+            )
+            .with_operation("stream_events")),
+            StreamFilter::WithMetadata(metadata) => Ok(event.metadata == *metadata),
+            StreamFilter::AfterVersion(version) => Ok(event.version > *version),
+            StreamFilter::CreatedAfter(timestamp) => Ok(event.created > *timestamp),
+            StreamFilter::WithAggregateVersion(v) => Ok(event.aggregate_version == *v),
+            StreamFilter::And(left, right) => {
+                Ok(Self::evaluate(left, event)? && Self::evaluate(right, event)?)
+            }
+            StreamFilter::Or(left, right) => {
+                Ok(Self::evaluate(left, event)? || Self::evaluate(right, event)?)
+            }
+            StreamFilter::Not(inner) => Ok(!Self::evaluate(inner, event)?),
+        }
+    }
+}
+
+impl Default for InMemoryEventStore {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl EventStore for InMemoryEventStore {
@@ -30,9 +87,17 @@ impl EventStore for InMemoryEventStore {
         let mut store = self.events.write().unwrap();
         let stream_id: Urn = stream_id.clone().into();
 
+        // Only count current (non-archived) events for the sequence version.
         let mut last_version = store
             .get(&stream_id)
-            .map(|events| events.last().map(|e| e.version).unwrap_or(0))
+            .map(|events| {
+                events
+                    .iter()
+                    .filter(|e| e.aggregate_version.is_none())
+                    .last()
+                    .map(|e| e.version)
+                    .unwrap_or(0)
+            })
             .unwrap_or(0);
 
         if let Some(expected_version) = expected_version {
@@ -62,6 +127,7 @@ impl EventStore for InMemoryEventStore {
                     version,
                     created,
                     metadata: metadata.clone(),
+                    aggregate_version: None,
                 })
             })
             .collect::<Result<Vec<_>, replay::Error>>();
@@ -77,29 +143,108 @@ impl EventStore for InMemoryEventStore {
         &self,
         filter: StreamFilter,
     ) -> impl TryStream<Ok = PersistedEvent<E>, Error = replay::Error> + Send {
-        // right now we only support filtering by stream id
+        // Optimise: if the filter references a specific stream URN, only scan that stream.
+        let candidate_events: Vec<PersistedEvent<Value>> = {
+            let store = self.events.read().unwrap();
+            if let Some(stream_id) = Self::extract_stream_id(&filter) {
+                store.get(&stream_id).cloned().unwrap_or_default()
+            } else {
+                store.values().flatten().cloned().collect()
+            }
+        };
 
         async_stream::stream! {
-
-            if let StreamFilter::WithStreamId(stream_id) = filter {
-                let stream = self.events.read().unwrap().get(&stream_id).cloned().unwrap_or_default();
-
-                for event in stream {
-                    let data: E = serde_json::from_value(event.data).map_err(crate::deser_error)?;
-                    yield Ok(PersistedEvent {
-                        id: event.id,
-                        data,
-                        stream_id: event.stream_id,
-                        r#type: event.r#type,
-                        version: event.version,
-                        created: event.created,
-                        metadata: event.metadata,
-                    });
+            for event in candidate_events {
+                match Self::evaluate(&filter, &event) {
+                    Err(e) => { yield Err(e); return; }
+                    Ok(false) => continue,
+                    Ok(true) => {}
                 }
+                let data: E = serde_json::from_value(event.data).map_err(crate::deser_error)?;
+                yield Ok(PersistedEvent {
+                    id: event.id,
+                    data,
+                    stream_id: event.stream_id,
+                    r#type: event.r#type,
+                    version: event.version,
+                    created: event.created,
+                    metadata: event.metadata,
+                    aggregate_version: event.aggregate_version,
+                });
+            }
+        }
+    }
 
-            } else {
-                yield Err(replay::Error::internal("Unsupported filter").with_operation("stream_events"));
-            };
+    async fn compact<A>(
+        &self,
+        aggregate: &A,
+        metadata: replay::Metadata,
+    ) -> Result<u32, replay::Error>
+    where
+        A: replay::Aggregate + Compactable + Sync,
+    {
+        let stream_id: Urn = aggregate.get_id().clone().into();
+
+        // 1. Collect current live events while holding the read lock (brief, sync).
+        //    Wrap them in a TryStream so that compacted_events can process them
+        //    without assuming an in-memory slice is available.
+        let current_events: Vec<A::Event> = {
+            let store = self.events.read().unwrap();
+            match store.get(&stream_id) {
+                None => Vec::new(),
+                Some(stream) => stream
+                    .iter()
+                    .filter(|e| e.aggregate_version.is_none())
+                    .map(|e| {
+                        serde_json::from_value::<A::Event>(e.data.clone())
+                            .map_err(crate::deser_error)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            }
+        };
+
+        let event_stream =
+            futures::stream::iter(current_events.into_iter().map(Ok::<_, replay::Error>));
+        let compacted = aggregate.compacted_events(event_stream).await?;
+
+        // 2. Determine the next archive version number and archive all current events.
+        {
+            let mut store = self.events.write().unwrap();
+            let stream = store.entry(stream_id.clone()).or_default();
+
+            let next_version: u32 = stream
+                .iter()
+                .filter_map(|e| e.aggregate_version)
+                .max()
+                .unwrap_or(0)
+                + 1;
+
+            // Archive: mark every current (aggregate_version = None) event with the new version.
+            for event in stream.iter_mut() {
+                if event.aggregate_version.is_none() {
+                    event.aggregate_version = Some(next_version);
+                }
+            }
+
+            // Insert compacted events as the new current stream (aggregate_version = None).
+            // Sequence versions restart from 1.
+            let mut seq: i64 = 0;
+            for event in &compacted {
+                seq += 1;
+                let data = serde_json::to_value(event).map_err(crate::ser_error)?;
+                stream.push(PersistedEvent {
+                    id: Uuid::new_v4(),
+                    data,
+                    stream_id: stream_id.clone(),
+                    r#type: event.event_type(),
+                    version: seq,
+                    created: Utc::now(),
+                    metadata: metadata.clone(),
+                    aggregate_version: None,
+                });
+            }
+
+            return Ok(next_version);
         }
     }
 }

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -180,11 +180,19 @@ impl EventStore for PostgresEventStore {
         //    Any concurrent `append_event` call that updates (or inserts into) this stream
         //    will block on this lock and only proceed after we commit, so no events can
         //    be appended between the read and the archive steps.
-        sqlx::query("SELECT id FROM streams WHERE id = $1 FOR UPDATE")
+        //    If the stream does not exist (0 rows matched) we return NotFound immediately
+        //    rather than silently producing an empty compaction for a phantom aggregate.
+        let lock_result = sqlx::query("SELECT id FROM streams WHERE id = $1 FOR UPDATE")
             .bind(&stream_id_str)
             .execute(&mut *tx)
             .await
             .map_err(crate::db_error)?;
+
+        if lock_result.rows_affected() == 0 {
+            return Err(replay::Error::not_found("Stream not found")
+                .with_operation("compact")
+                .with_context("stream_id", stream_id_str));
+        }
 
         // 2. Read the current live events inside the transaction (now protected by the lock).
         //    Using fetch_all here is intentional: compaction is a maintenance operation and

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -61,7 +61,7 @@ impl PostgresEventStore {
                 Some(version) => {
                     query_builder
                         .push(" aggregate_version = ")
-                        .push_bind(version as i32);
+                        .push_bind(version);
                 }
             },
             StreamFilter::And(left, right) => {
@@ -167,7 +167,7 @@ impl EventStore for PostgresEventStore {
         &self,
         aggregate: &A,
         metadata: replay::Metadata,
-    ) -> Result<u32, replay::Error>
+    ) -> Result<i32, replay::Error>
     where
         A: replay::Aggregate + Compactable + Sync,
     {
@@ -253,7 +253,7 @@ impl EventStore for PostgresEventStore {
 
         tx.commit().await.map_err(crate::db_error)?;
 
-        Ok(next_version as u32)
+        Ok(next_version)
     }
 }
 
@@ -296,7 +296,7 @@ impl<D: DeserializeOwned> TryFrom<PgRow> for PersistedEvent<D> {
             version,
             created,
             metadata,
-            aggregate_version: aggregate_version.map(|v| v as u32),
+            aggregate_version,
         })
     }
 }

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -174,25 +174,42 @@ impl EventStore for PostgresEventStore {
         let stream_id: Urn = aggregate.get_id().clone().into();
         let stream_id_str = stream_id.to_string();
 
-        // 1. Stream current live events lazily from the pool (outside any transaction)
-        //    and compute the compacted set without loading the full history into memory.
-        let event_stream = sqlx::query(
+        let mut tx = self.pool.begin().await.map_err(crate::db_error)?;
+
+        // 1. Lock the stream row for the duration of this transaction.
+        //    Any concurrent `append_event` call that updates (or inserts into) this stream
+        //    will block on this lock and only proceed after we commit, so no events can
+        //    be appended between the read and the archive steps.
+        sqlx::query("SELECT id FROM streams WHERE id = $1 FOR UPDATE")
+            .bind(&stream_id_str)
+            .execute(&mut *tx)
+            .await
+            .map_err(crate::db_error)?;
+
+        // 2. Read the current live events inside the transaction (now protected by the lock).
+        //    Using fetch_all here is intentional: compaction is a maintenance operation and
+        //    the lock must be held for the entire read + archive window, which precludes
+        //    interleaving other queries on the same connection.
+        let rows = sqlx::query(
             "SELECT data FROM events WHERE stream_id = $1 AND aggregate_version IS NULL ORDER BY version",
         )
         .bind(&stream_id_str)
-        .fetch(&self.pool)
-        .map(|r| {
-            let row = r.map_err(crate::db_error)?;
-            let data: serde_json::Value = row.get("data");
-            serde_json::from_value::<A::Event>(data).map_err(crate::deser_error)
-        });
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(crate::db_error)?;
 
+        let events: Vec<Result<A::Event, replay::Error>> = rows
+            .into_iter()
+            .map(|row: sqlx::postgres::PgRow| {
+                let data: serde_json::Value = row.get("data");
+                serde_json::from_value::<A::Event>(data).map_err(crate::deser_error)
+            })
+            .collect();
+
+        let event_stream = futures::stream::iter(events);
         let compacted = aggregate.compacted_events(event_stream).await?;
-        // event_stream fully consumed; pool borrow released.
 
-        let mut tx = self.pool.begin().await.map_err(crate::db_error)?;
-
-        // 2. Determine the next archive version number.
+        // 3. Determine the next archive version number.
         let next_version: i32 = sqlx::query_scalar(
             "SELECT COALESCE(MAX(aggregate_version), 0) + 1 FROM events WHERE stream_id = $1",
         )
@@ -201,7 +218,7 @@ impl EventStore for PostgresEventStore {
         .await
         .map_err(crate::db_error)?;
 
-        // 3. Archive all current (un-versioned) events for this stream.
+        // 4. Archive all current (un-versioned) events for this stream.
         sqlx::query(
             "UPDATE events SET aggregate_version = $1 WHERE stream_id = $2 AND aggregate_version IS NULL",
         )
@@ -211,14 +228,14 @@ impl EventStore for PostgresEventStore {
         .await
         .map_err(crate::db_error)?;
 
-        // 4. Reset the stream's version counter so compacted events start from 1.
+        // 5. Reset the stream's version counter so compacted events start from 1.
         sqlx::query("UPDATE streams SET version = 0 WHERE id = $1")
             .bind(&stream_id_str)
             .execute(&mut *tx)
             .await
             .map_err(crate::db_error)?;
 
-        // 5. Insert compacted events as the new current stream (aggregate_version = NULL).
+        // 6. Insert compacted events as the new current stream (aggregate_version = NULL).
         let stream_type = A::stream_type();
         let meta_json = metadata.to_json();
         for (seq, event) in compacted.iter().enumerate() {
@@ -241,7 +258,7 @@ impl EventStore for PostgresEventStore {
             .map_err(crate::db_error)?;
         }
 
-        // 6. Update the stream version to the count of compacted events.
+        // 7. Update the stream version to the count of compacted events.
         let new_stream_version = compacted.len() as i64;
         sqlx::query("UPDATE streams SET version = $1, type = $2 WHERE id = $3")
             .bind(new_stream_version)

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -11,7 +11,7 @@ use urn::Urn;
 use uuid::Uuid;
 
 use crate::{EventStore, PersistedEvent, StreamFilter};
-use replay::{Event, Metadata};
+use replay::{Compactable, Event, Metadata};
 
 pub struct PostgresEventStore {
     pool: Pool<Postgres>,
@@ -54,6 +54,16 @@ impl PostgresEventStore {
             StreamFilter::CreatedAfter(timestamp) => {
                 query_builder.push(" created > ").push_bind(timestamp);
             }
+            StreamFilter::WithAggregateVersion(v) => match v {
+                None => {
+                    query_builder.push(" aggregate_version IS NULL");
+                }
+                Some(version) => {
+                    query_builder
+                        .push(" aggregate_version = ")
+                        .push_bind(version as i32);
+                }
+            },
             StreamFilter::And(left, right) => {
                 query_builder.push(" (");
                 Self::add_filters(query_builder, *left);
@@ -125,7 +135,7 @@ impl EventStore for PostgresEventStore {
         filter: StreamFilter,
     ) -> impl TryStream<Ok = PersistedEvent<E>, Error = replay::Error> + Send {
         async_stream::stream! {
-            let sql = "SELECT id, data, metadata, stream_id, type, version, created
+            let sql = "SELECT id, data, metadata, stream_id, type, version, created, aggregate_version
                 FROM events 
                 WHERE " ;
 
@@ -133,8 +143,6 @@ impl EventStore for PostgresEventStore {
             Self::add_filters(&mut query_builder, filter.clone());
 
             let query_builder = query_builder.push(" ORDER BY created, version ASC");
-
-            //println!("Executing query: {}", query_builder.sql());
 
             let mut rows = query_builder
                 .build()
@@ -153,6 +161,99 @@ impl EventStore for PostgresEventStore {
 
             tracing::debug!("Streamed {} events from Postgres", count);
         }
+    }
+
+    async fn compact<A>(
+        &self,
+        aggregate: &A,
+        metadata: replay::Metadata,
+    ) -> Result<u32, replay::Error>
+    where
+        A: replay::Aggregate + Compactable + Sync,
+    {
+        let stream_id: Urn = aggregate.get_id().clone().into();
+        let stream_id_str = stream_id.to_string();
+
+        // 1. Stream current live events lazily from the pool (outside any transaction)
+        //    and compute the compacted set without loading the full history into memory.
+        let event_stream = sqlx::query(
+            "SELECT data FROM events WHERE stream_id = $1 AND aggregate_version IS NULL ORDER BY version",
+        )
+        .bind(&stream_id_str)
+        .fetch(&self.pool)
+        .map(|r| {
+            let row = r.map_err(crate::db_error)?;
+            let data: serde_json::Value = row.get("data");
+            serde_json::from_value::<A::Event>(data).map_err(crate::deser_error)
+        });
+
+        let compacted = aggregate.compacted_events(event_stream).await?;
+        // event_stream fully consumed; pool borrow released.
+
+        let mut tx = self.pool.begin().await.map_err(crate::db_error)?;
+
+        // 2. Determine the next archive version number.
+        let next_version: i32 = sqlx::query_scalar(
+            "SELECT COALESCE(MAX(aggregate_version), 0) + 1 FROM events WHERE stream_id = $1",
+        )
+        .bind(&stream_id_str)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(crate::db_error)?;
+
+        // 3. Archive all current (un-versioned) events for this stream.
+        sqlx::query(
+            "UPDATE events SET aggregate_version = $1 WHERE stream_id = $2 AND aggregate_version IS NULL",
+        )
+        .bind(next_version)
+        .bind(&stream_id_str)
+        .execute(&mut *tx)
+        .await
+        .map_err(crate::db_error)?;
+
+        // 4. Reset the stream's version counter so compacted events start from 1.
+        sqlx::query("UPDATE streams SET version = 0 WHERE id = $1")
+            .bind(&stream_id_str)
+            .execute(&mut *tx)
+            .await
+            .map_err(crate::db_error)?;
+
+        // 5. Insert compacted events as the new current stream (aggregate_version = NULL).
+        let stream_type = A::stream_type();
+        let meta_json = metadata.to_json();
+        for (seq, event) in compacted.iter().enumerate() {
+            let event_type = event.event_type();
+            let data = serde_json::to_value(event).map_err(crate::ser_error)?;
+            let version = (seq as i64) + 1;
+
+            sqlx::query(
+                "INSERT INTO events (id, data, metadata, stream_id, type, version, aggregate_version)
+                 VALUES ($1, $2, $3, $4, $5, $6, NULL)",
+            )
+            .bind(Uuid::new_v4())
+            .bind(&data)
+            .bind(&meta_json)
+            .bind(&stream_id_str)
+            .bind(&event_type)
+            .bind(version)
+            .execute(&mut *tx)
+            .await
+            .map_err(crate::db_error)?;
+        }
+
+        // 6. Update the stream version to the count of compacted events.
+        let new_stream_version = compacted.len() as i64;
+        sqlx::query("UPDATE streams SET version = $1, type = $2 WHERE id = $3")
+            .bind(new_stream_version)
+            .bind(&stream_type)
+            .bind(&stream_id_str)
+            .execute(&mut *tx)
+            .await
+            .map_err(crate::db_error)?;
+
+        tx.commit().await.map_err(crate::db_error)?;
+
+        Ok(next_version as u32)
     }
 }
 
@@ -185,6 +286,7 @@ impl<D: DeserializeOwned> TryFrom<PgRow> for PersistedEvent<D> {
         let created: chrono::DateTime<Utc> = value.get("created");
         let metadata: Value = value.get("metadata");
         let metadata: Metadata = Metadata::new(metadata);
+        let aggregate_version: Option<i32> = value.get("aggregate_version");
 
         Ok(PersistedEvent {
             id,
@@ -194,6 +296,7 @@ impl<D: DeserializeOwned> TryFrom<PgRow> for PersistedEvent<D> {
             version,
             created,
             metadata,
+            aggregate_version: aggregate_version.map(|v| v as u32),
         })
     }
 }

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -51,8 +51,14 @@ impl PostgresEventStore {
             StreamFilter::AfterVersion(version) => {
                 query_builder.push(" version > ").push_bind(version);
             }
+            StreamFilter::UpToVersion(version) => {
+                query_builder.push(" version <= ").push_bind(version);
+            }
             StreamFilter::CreatedAfter(timestamp) => {
                 query_builder.push(" created > ").push_bind(timestamp);
+            }
+            StreamFilter::CreatedBefore(timestamp) => {
+                query_builder.push(" created <= ").push_bind(timestamp);
             }
             StreamFilter::WithAggregateVersion(v) => match v {
                 None => {

--- a/persistence/src/lib.rs
+++ b/persistence/src/lib.rs
@@ -1,3 +1,4 @@
+mod aggregate_version;
 mod cqrs;
 mod error;
 mod filters;
@@ -6,6 +7,7 @@ mod persisted_event;
 mod query;
 mod store;
 
+pub use aggregate_version::AggregateVersion;
 pub use cqrs::Cqrs;
 pub use error::{concurrency_error, db_error, deser_error, ser_error};
 pub use filters::StreamFilter;

--- a/persistence/src/persisted_event.rs
+++ b/persistence/src/persisted_event.rs
@@ -10,9 +10,13 @@ pub struct PersistedEvent<E> {
     pub data: E,
     pub stream_id: Urn,
     pub r#type: String,
+    /// Monotonic position of this event within the aggregate's current stream.
     pub version: i64,
     pub created: DateTime<Utc>,
     pub metadata: Metadata,
+    /// `None` identifies events belonging to the current (latest) stream.
+    /// `Some(n)` identifies events that were archived during the nth compaction.
+    pub aggregate_version: Option<u32>,
 }
 
 impl<E> PersistedEvent<E> {
@@ -25,6 +29,7 @@ impl<E> PersistedEvent<E> {
             version: self.version,
             created: self.created,
             metadata: self.metadata,
+            aggregate_version: self.aggregate_version,
         }
     }
 
@@ -37,6 +42,7 @@ impl<E> PersistedEvent<E> {
             version: self.version,
             created: self.created,
             metadata: self.metadata,
+            aggregate_version: self.aggregate_version,
         }
     }
 }

--- a/persistence/src/persisted_event.rs
+++ b/persistence/src/persisted_event.rs
@@ -16,7 +16,8 @@ pub struct PersistedEvent<E> {
     pub metadata: Metadata,
     /// `None` identifies events belonging to the current (latest) stream.
     /// `Some(n)` identifies events that were archived during the nth compaction.
-    pub aggregate_version: Option<u32>,
+    /// Matches the `INTEGER` column type in the database.
+    pub aggregate_version: Option<i32>,
 }
 
 impl<E> PersistedEvent<E> {

--- a/persistence/src/store.rs
+++ b/persistence/src/store.rs
@@ -61,7 +61,7 @@ pub trait EventStore: Send + Sync {
         &self,
         aggregate: &A,
         metadata: replay::Metadata,
-    ) -> impl Future<Output = Result<u32, replay::Error>> + Send
+    ) -> impl Future<Output = Result<i32, replay::Error>> + Send
     where
         A: replay::Aggregate + Compactable + Sync;
 }

--- a/persistence/src/store.rs
+++ b/persistence/src/store.rs
@@ -26,8 +26,10 @@ pub trait EventStore: Send + Sync {
     ///
     /// - `aggregate_version`: `Latest` loads the current (non-archived) events; `Version(n)`
     ///   loads the events that were archived during the nth compaction run.
-    /// - `at_stream_version`: upper bound on the event sequence number (for time-travel queries).
-    /// - `at_timestamp`: upper bound on the event creation timestamp.
+    /// - `at_stream_version`: inclusive upper bound on the event sequence number
+    ///   (events with version ≤ n are included; use for time-travel reads).
+    /// - `at_timestamp`: inclusive upper bound on the event creation timestamp
+    ///   (events created at or before the given instant are included).
     fn stream_events_by_stream_id<S: replay::EventStream>(
         &self,
         stream_id: &S::StreamId,

--- a/persistence/src/store.rs
+++ b/persistence/src/store.rs
@@ -2,9 +2,9 @@ use std::future::Future;
 
 use futures::TryStream;
 
-use replay::Event;
+use replay::{Compactable, Event};
 
-use super::PersistedEvent;
+use super::{AggregateVersion, PersistedEvent};
 
 pub trait EventStore: Send + Sync {
     fn store_events<S: replay::EventStream>(
@@ -21,16 +21,47 @@ pub trait EventStore: Send + Sync {
         filter: crate::StreamFilter,
     ) -> impl TryStream<Ok = PersistedEvent<E>, Error = replay::Error> + Send;
 
+    /// Stream the events for a specific aggregate stream, optionally scoped to a particular
+    /// compaction version.
+    ///
+    /// - `aggregate_version`: `Latest` loads the current (non-archived) events; `Version(n)`
+    ///   loads the events that were archived during the nth compaction run.
+    /// - `at_stream_version`: upper bound on the event sequence number (for time-travel queries).
+    /// - `at_timestamp`: upper bound on the event creation timestamp.
     fn stream_events_by_stream_id<S: replay::EventStream>(
         &self,
         stream_id: &S::StreamId,
+        aggregate_version: AggregateVersion,
         at_stream_version: Option<i64>,
         at_timestamp: Option<chrono::DateTime<chrono::Utc>>,
     ) -> impl TryStream<Ok = PersistedEvent<S::Event>, Error = replay::Error> + Send {
         let filter = crate::StreamFilter::WithStreamId(stream_id.clone().into())
+            .and_aggregate_version(aggregate_version.as_option())
             .and_at_stream_version_optional(at_stream_version)
             .and_at_timestamp_optional(at_timestamp);
 
         self.stream_events::<S::Event>(filter)
     }
+
+    /// Compact the event stream for an aggregate.
+    ///
+    /// The method performs the following steps atomically (where the store supports it):
+    ///
+    /// 1. Determines the next archive version number (max existing archive version + 1, starting
+    ///    at 1 for the first compaction).
+    /// 2. Copies all current events (those with no aggregate version tag) for the given aggregate
+    ///    into the new archive version.
+    /// 3. Removes all current (un-versioned) events for the aggregate from the live stream.
+    /// 4. Calls [`Compactable::compacted_events`] on the aggregate, passing the current live
+    ///    events, to obtain the minimal event set.
+    /// 5. Persists the compacted events as the new current event stream (no version tag).
+    ///
+    /// Returns the archive version number that was created.
+    fn compact<A>(
+        &self,
+        aggregate: &A,
+        metadata: replay::Metadata,
+    ) -> impl Future<Output = Result<u32, replay::Error>> + Send
+    where
+        A: replay::Aggregate + Compactable + Sync;
 }

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -1,3 +1,4 @@
+use futures::TryStreamExt;
 use serde::{Deserialize, Serialize};
 
 use sqlx::{postgres::PgPoolOptions, PgPool};
@@ -5,9 +6,9 @@ use testcontainers_modules::{postgres, testcontainers::runners::AsyncRunner};
 use tokio_test::assert_err;
 use urn::{Urn, UrnBuilder};
 
-use replay::WithId;
+use replay::{Compactable, WithId};
 use replay_macros::{Event, Urn};
-use replay_persistence::{PersistedEvent, StreamFilter};
+use replay_persistence::{AggregateVersion, EventStore, PersistedEvent, StreamFilter};
 
 const POSTGRES_PORT: u16 = 5432;
 
@@ -18,7 +19,7 @@ struct BankAccountAggregate {
     pub balance: f64,
 }
 
-// create bank account commands
+// bank account commands
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 enum BankAccountCommand {
     Deposit {
@@ -29,9 +30,12 @@ enum BankAccountCommand {
         effective_on: chrono::NaiveDate,
         amount: f64,
     },
+    /// Formally close the month identified by `month`.  The closing balance is
+    /// derived from the aggregate's current in-memory state.
+    CloseMonth { month: chrono::NaiveDate },
 }
 
-// create bank account events enum: Deposited and Withdrawn
+// bank account events
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Event)]
 enum BankAccountEvent {
     Deposited {
@@ -42,15 +46,13 @@ enum BankAccountEvent {
         operation_date: chrono::NaiveDate,
         amount: f64,
     },
-}
-
-impl BankAccountEvent {
-    fn operation_date(&self) -> chrono::NaiveDate {
-        match self {
-            BankAccountEvent::Deposited { operation_date, .. } => *operation_date,
-            BankAccountEvent::Withdrawn { operation_date, .. } => *operation_date,
-        }
-    }
+    /// Summarises all activity up to and including a completed calendar month.
+    /// Carries the closing balance so the aggregate can be restored from this
+    /// single event without replaying every prior transaction.
+    MonthlyClosed {
+        month: chrono::NaiveDate,
+        closing_balance: f64,
+    },
 }
 
 // bank account urn
@@ -98,17 +100,12 @@ impl replay::EventStream for BankAccountAggregate {
 
     fn apply(&mut self, event: Self::Event) {
         match event {
-            BankAccountEvent::Deposited {
-                operation_date: _,
-                amount,
+            BankAccountEvent::Deposited { amount, .. } => self.balance += amount,
+            BankAccountEvent::Withdrawn { amount, .. } => self.balance -= amount,
+            BankAccountEvent::MonthlyClosed {
+                closing_balance, ..
             } => {
-                self.balance += amount;
-            }
-            BankAccountEvent::Withdrawn {
-                operation_date: _,
-                amount,
-            } => {
-                self.balance -= amount;
+                self.balance = closing_balance;
             }
         }
     }
@@ -152,7 +149,33 @@ impl replay::Aggregate for BankAccountAggregate {
                 };
                 Ok(vec![event])
             }
+            // Close the current month; closing balance is taken from aggregate state.
+            BankAccountCommand::CloseMonth { month } => Ok(vec![BankAccountEvent::MonthlyClosed {
+                month,
+                closing_balance: self.balance,
+            }]),
         }
+    }
+}
+
+impl Compactable for BankAccountAggregate {
+    async fn compacted_events(
+        &self,
+        events: impl futures::TryStream<Ok = BankAccountEvent, Error = replay::Error> + Send,
+    ) -> replay::Result<Vec<BankAccountEvent>> {
+        use futures::TryStreamExt;
+        // Sliding-window scan via try_fold: only the events from the last
+        // MonthlyClosed onward are kept in the accumulator at any time.
+        // Closed months are never accumulated in memory.
+        events
+            .try_fold(Vec::new(), |mut tail, event| async move {
+                if matches!(event, BankAccountEvent::MonthlyClosed { .. }) {
+                    tail.clear(); // drop everything before this summary checkpoint
+                }
+                tail.push(event);
+                Ok(tail)
+            })
+            .await
     }
 }
 
@@ -189,31 +212,39 @@ impl replay_persistence::Query for BankAccountStatement {
     }
 
     fn update(&mut self, event: PersistedEvent<Self::Event>) {
-        let event = event.data;
-
-        // right now we don't have filters for "after timestamp" so we need to apply here
-        if event.operation_date() > self.to || event.operation_date() < self.from {
-            return;
-        }
-
-        self.transactions.push(event.clone());
-
-        match event {
+        // Summary events are not individual transactions and are excluded from statements.
+        match event.data {
             BankAccountEvent::Deposited {
-                operation_date: _,
+                operation_date,
                 amount,
             } => {
+                if operation_date < self.from || operation_date > self.to {
+                    return;
+                }
+                self.transactions.push(BankAccountEvent::Deposited {
+                    operation_date,
+                    amount,
+                });
                 self.balance_change += amount;
+                self.total_transactions += 1;
             }
             BankAccountEvent::Withdrawn {
-                operation_date: _,
+                operation_date,
                 amount,
             } => {
+                if operation_date < self.from || operation_date > self.to {
+                    return;
+                }
+                self.transactions.push(BankAccountEvent::Withdrawn {
+                    operation_date,
+                    amount,
+                });
                 self.balance_change -= amount;
+                self.total_transactions += 1;
             }
+            // MonthlyClosed is a compaction marker — not an individual statement line.
+            BankAccountEvent::MonthlyClosed { .. } => {}
         }
-
-        self.total_transactions += 1;
     }
 }
 
@@ -363,4 +394,177 @@ async fn connect_to_postgres(host: String, port: u16) -> PgPool {
         ))
         .await
         .expect("Failed to create postgres pool")
+}
+
+/// Tests the full compaction lifecycle for a bank account aggregate.
+///
+/// Scenario:
+///  - Three transactions are recorded in January (deposit, withdraw, deposit → balance 1 300).
+///  - January is formally closed via `CloseMonth` which emits a `MonthlyClosed` event.
+///  - Two transactions are recorded in February (deposit, withdraw → balance 1 600).
+///  - `Cqrs::compact` is called; it archives the 6-event full history as Version(1) and
+///    replaces the live stream with 3 compacted events:
+///      MonthlyClosed(Jan, 1300) + Deposited(Feb) + Withdrawn(Feb).
+///  - The aggregate balance after replaying the compacted stream must equal 1 600.
+///  - The archived Version(1) must still contain all 6 original events.
+#[tokio::test]
+async fn bank_account_compaction_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    // Keep a clone of the store for direct streaming after compaction.
+    let store = replay_persistence::PostgresEventStore::new(pg_pool);
+    let cqrs = replay_persistence::Cqrs::new(store.clone());
+
+    let stream_id = BankAccountUrn(
+        UrnBuilder::new("bank-account", "compact-1")
+            .build()
+            .unwrap(),
+    );
+    let services = &();
+    let meta = replay::Metadata::default();
+
+    // Convenient date helpers.
+    let jan_1 = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+    let jan_15 = chrono::NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
+    let jan_31 = chrono::NaiveDate::from_ymd_opt(2026, 1, 31).unwrap();
+    let feb_15 = chrono::NaiveDate::from_ymd_opt(2026, 2, 15).unwrap();
+    let feb_28 = chrono::NaiveDate::from_ymd_opt(2026, 2, 28).unwrap();
+
+    // ── January: three transactions ──────────────────────────────────────────
+    // After these: balance = 1000 - 200 + 500 = 1300.
+    for cmd in [
+        BankAccountCommand::Deposit {
+            effective_on: jan_1,
+            amount: 1000.0,
+        },
+        BankAccountCommand::Withdraw {
+            effective_on: jan_15,
+            amount: 200.0,
+        },
+        BankAccountCommand::Deposit {
+            effective_on: jan_31,
+            amount: 500.0,
+        },
+    ] {
+        cqrs.execute::<BankAccountAggregate>(&stream_id, meta.clone(), cmd, services, None)
+            .await
+            .unwrap();
+    }
+
+    // ── Close January ─────────────────────────────────────────────────────────
+    // CloseMonth derives closing_balance from current aggregate state (1300).
+    cqrs.execute::<BankAccountAggregate>(
+        &stream_id,
+        meta.clone(),
+        BankAccountCommand::CloseMonth { month: jan_1 },
+        services,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // ── February: two transactions ───────────────────────────────────────────
+    // After these: balance = 1300 + 400 - 100 = 1600.
+    for cmd in [
+        BankAccountCommand::Deposit {
+            effective_on: feb_15,
+            amount: 400.0,
+        },
+        BankAccountCommand::Withdraw {
+            effective_on: feb_28,
+            amount: 100.0,
+        },
+    ] {
+        cqrs.execute::<BankAccountAggregate>(&stream_id, meta.clone(), cmd, services, None)
+            .await
+            .unwrap();
+    }
+
+    // Full history at this point: 6 events (3 Jan + MonthlyClosed + 2 Feb).
+    let aggregate = cqrs
+        .fetch_aggregate::<BankAccountAggregate>(&stream_id, AggregateVersion::Latest, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(aggregate.balance, 1600.0);
+
+    // ── Compact ──────────────────────────────────────────────────────────────
+    let archive_version = cqrs.compact(&aggregate, meta.clone()).await.unwrap();
+    assert_eq!(
+        archive_version, 1,
+        "First compaction must produce archive version 1"
+    );
+
+    // ── Verify: balance unchanged after replaying compacted stream ────────────
+    let compacted_aggregate = cqrs
+        .fetch_aggregate::<BankAccountAggregate>(&stream_id, AggregateVersion::Latest, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        compacted_aggregate.balance, 1600.0,
+        "Replaying the compacted stream must yield the same balance"
+    );
+
+    // ── Verify: live stream now has exactly 3 events ──────────────────────────
+    // Expected: MonthlyClosed(Jan,1300) · Deposited(Feb) · Withdrawn(Feb)
+    let live_events: Vec<_> = store
+        .stream_events_by_stream_id::<BankAccountAggregate>(
+            &stream_id,
+            AggregateVersion::Latest,
+            None,
+            None,
+        )
+        .try_collect()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        live_events.len(),
+        3,
+        "Compacted live stream must have 3 events"
+    );
+    assert!(
+        matches!(live_events[0].data, BankAccountEvent::MonthlyClosed { .. }),
+        "First compacted event must be MonthlyClosed"
+    );
+    assert!(
+        matches!(live_events[1].data, BankAccountEvent::Deposited { .. }),
+        "Second compacted event must be the February Deposited"
+    );
+    assert!(
+        matches!(live_events[2].data, BankAccountEvent::Withdrawn { .. }),
+        "Third compacted event must be the February Withdrawn"
+    );
+
+    // ── Verify: full history still accessible as Version(1) ───────────────────
+    let archived_events: Vec<_> = store
+        .stream_events_by_stream_id::<BankAccountAggregate>(
+            &stream_id,
+            AggregateVersion::Version(1),
+            None,
+            None,
+        )
+        .try_collect()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        archived_events.len(),
+        6,
+        "Archived Version(1) must retain all 6 original events"
+    );
 }

--- a/persistence/tests/migrations/0002_aggregate_version.sql
+++ b/persistence/tests/migrations/0002_aggregate_version.sql
@@ -1,0 +1,21 @@
+-- Add aggregate_version column to events table.
+-- NULL  = current (live) event stream for this aggregate.
+-- n > 0 = events archived during the nth compaction run.
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS aggregate_version INTEGER DEFAULT NULL;
+
+-- Drop the existing unique constraint on (stream_id, version) because after
+-- compaction the archived events keep their original version numbers while the
+-- freshly inserted compacted events restart from 1 — so (stream_id, version)
+-- is no longer globally unique. The new uniqueness scope is
+-- (stream_id, version, aggregate_version).
+ALTER TABLE events
+    DROP CONSTRAINT IF EXISTS events_stream_and_version;
+
+ALTER TABLE events
+    ADD CONSTRAINT events_stream_version_agg
+        UNIQUE (stream_id, version, aggregate_version);
+
+-- Index to speed up compaction queries and version-scoped replays.
+CREATE INDEX IF NOT EXISTS idx_events_aggregate_version
+    ON events (stream_id, aggregate_version);

--- a/persistence/tests/migrations/0002_aggregate_version.sql
+++ b/persistence/tests/migrations/0002_aggregate_version.sql
@@ -7,14 +7,29 @@ ALTER TABLE events
 -- Drop the existing unique constraint on (stream_id, version) because after
 -- compaction the archived events keep their original version numbers while the
 -- freshly inserted compacted events restart from 1 — so (stream_id, version)
--- is no longer globally unique. The new uniqueness scope is
--- (stream_id, version, aggregate_version).
+-- is no longer globally unique.
+--
+-- We cannot use a single UNIQUE constraint on (stream_id, version, aggregate_version)
+-- because Postgres treats NULLs as distinct in UNIQUE constraints, which would allow
+-- multiple live events with the same (stream_id, version) when aggregate_version IS NULL.
+--
+-- Instead we use two partial unique indexes:
+--   1. Live stream  (aggregate_version IS NULL):
+--        (stream_id, version) must be unique — enforces the concurrency guarantee
+--        that no two current events share the same sequence number.
+--   2. Archived streams (aggregate_version IS NOT NULL):
+--        (stream_id, version, aggregate_version) must be unique — each archived
+--        snapshot version has its own contiguous event sequence.
 ALTER TABLE events
     DROP CONSTRAINT IF EXISTS events_stream_and_version;
 
-ALTER TABLE events
-    ADD CONSTRAINT events_stream_version_agg
-        UNIQUE (stream_id, version, aggregate_version);
+CREATE UNIQUE INDEX IF NOT EXISTS uidx_events_live_version
+    ON events (stream_id, version)
+    WHERE aggregate_version IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uidx_events_archived_version
+    ON events (stream_id, version, aggregate_version)
+    WHERE aggregate_version IS NOT NULL;
 
 -- Index to speed up compaction queries and version-scoped replays.
 CREATE INDEX IF NOT EXISTS idx_events_aggregate_version


### PR DESCRIPTION
- Add Compactable trait with async compacted_events(TryStream) signature
- Add AggregateVersion enum (Latest | Version(i32)) to EventStore queries
- Add compact() method to EventStore, InMemoryEventStore, PostgresEventStore, Cqrs
- Add aggregate_version column to PersistedEvent and StreamFilter
- Add WithAggregateVersion filter variant and evaluate() method
- Add migration 0002_aggregate_version.sql
- Add bank-account compaction integration test with MonthlyClosed event
- Update rustdoc and README with compaction example and strategy