### PR TITLE
feat: add scoped URN composition via WithId::at and extract_scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,6 +857,71 @@ active_products.insert(product2);
 assert_eq!(active_products.len(), 2);
 ```
 
+### Composing Scoped URNs
+
+When two streams are related (e.g., a product belonging to a catalog), you can embed that
+relationship directly in the URN using `WithId::at` and recover it with `WithId::extract_scope`.
+
+The resulting URN uses the format `urn:<nid>:<nss>@<scope_nid>:<scope_nss>`.
+
+```rust
+use replay::WithId;
+
+// urn:product:sku123  +  urn:catalog:that  →  urn:product:sku123@catalog:that
+let scoped = product.at(catalog_id)?;
+println!("{}", scoped.get_id()); // urn:product:sku123@catalog:that
+
+// Extract the scope back — specify the expected output type as a type parameter.
+// The output type's TryFrom<Urn> implementation validates the NID.
+let catalog: CatalogUrn = scoped.extract_scope::<CatalogUrn>()?;
+```
+
+`at` accepts any type that is `Into<Urn>`, which includes every `StreamId` in the library.
+This means you pass a typed URN directly by value; no raw `Urn` wrapping is required:
+
+```rust
+let catalog_urn: CatalogUrn = CatalogUrn::new("winter-2026").unwrap();
+let product_urn: ProductUrn = ProductUrn::new("sku-999").unwrap();
+
+// scope the product under the catalog
+let scoped_product = product.at(catalog_urn)?;
+// → urn:product:sku-999@catalog:winter-2026
+```
+
+`extract_scope` is **generic over the output type**. You declare what URN type you expect and
+the conversion is handled by that type's `TryFrom<Urn>` implementation, which is responsible
+for validating the NID. Requesting the wrong type is a compile-time-safe, runtime-checked error:
+
+```rust
+// ✅ correct — scope NID is "catalog", CatalogUrn accepts it
+let catalog: CatalogUrn = scoped_product.extract_scope::<CatalogUrn>()?;
+
+// ❌ wrong type — scope NID is "catalog", but ProductUrn expects "product"
+let wrong: ProductUrn = scoped_product.extract_scope::<ProductUrn>()?; // Err: NID mismatch
+```
+
+**Validation rules enforced by `at`:**
+
+| Condition | Error |
+|---|---|
+| NSS already contains `@` | "URN is already scoped" |
+
+**Validation rules enforced by `extract_scope`:**
+
+| Input NSS | Error |
+|---|---|
+| `sku123` — no `@` | "not scoped (no '@' in NSS)" |
+| `@catalog:that` — empty own NSS | "empty NSS before '@'" |
+| `sku123@catalog` — no `:` after `@` | "missing ':' (expected '<nid>:<nss>')" |
+| `sku@:nss` — empty scope NID | "Scope NID is empty" |
+| `sku@nid:` — empty scope NSS | "Scope NSS is empty" |
+| `a@b:c@d:e` — multiple `@` | "multiple '@' in NSS (ambiguous scope)" |
+| wrong output type | "NID mismatch" (from `TryFrom<Urn>` on the output type) |
+
+The output type can be any type that implements `TryFrom<Urn>` — it does not have to be the
+same as `Self::StreamId`. This allows a `ProductStream` to extract a `CatalogUrn`, a `TenantUrn`,
+or any other domain type, as long as the NID embedded in the scope part matches.
+
 ## WASM Support
 
 The library supports WebAssembly (WASM) targets with automatic adjustments for single-threaded environments:

--- a/es/src/stream.rs
+++ b/es/src/stream.rs
@@ -47,6 +47,143 @@ pub trait WithId: Sized {
 
         Ok(Self::with_id(aggregate_id))
     }
+
+    /// Returns a new instance whose stream ID has the suffix `@<other.nid>:<other.nss>` appended
+    /// to the current URN's NSS, scoping this stream under `other`.
+    ///
+    /// `other` can be any type that converts into a [`Urn`] — typically another aggregate's
+    /// `StreamId`.
+    ///
+    /// Fails if the current URN's NSS already contains `@`, which would indicate the stream is
+    /// already scoped.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // urn:product:sku123  +  urn:catalog:that  →  urn:product:sku123@catalog:that
+    /// let scoped: ProductUrn = product_urn.at(catalog_urn)?;
+    /// ```
+    fn at(&self, other: impl Into<Urn>) -> crate::Result<Self> {
+        let current_urn: Urn = self.get_id().clone().into();
+        let other_urn: Urn = other.into();
+
+        if current_urn.nss().contains('@') {
+            return Err(Error::invalid_input("URN is already scoped (contains '@')")
+                .with_operation("at")
+                .with_context("urn", current_urn.to_string()));
+        }
+
+        let new_nss = format!(
+            "{}@{}:{}",
+            current_urn.nss(),
+            other_urn.nid(),
+            other_urn.nss()
+        );
+
+        let new_urn = urn::UrnBuilder::new(current_urn.nid(), &new_nss)
+            .build()
+            .map_err(|e| {
+                Error::invalid_input("Failed to build scoped URN")
+                    .with_operation("at")
+                    .with_context("nss", new_nss.clone())
+                    .with_context("error", format!("{:?}", e))
+            })?;
+
+        let id: Self::StreamId = new_urn.try_into().map_err(|e| {
+            Error::invalid_input("Failed to convert scoped URN to StreamId")
+                .with_operation("at")
+                .with_context("error", format!("{:?}", e))
+        })?;
+
+        Ok(Self::with_id(id))
+    }
+
+    /// Extracts the scope URN that was embedded by [`Self::at`].
+    ///
+    /// The expected NSS format is `<nss>@<scope_nid>:<scope_nss>` where:
+    /// - `<nss>` is non-empty
+    /// - `<scope_nid>` and `<scope_nss>` are both non-empty
+    /// - there is exactly one `@`
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidInput` when:
+    /// - the NSS contains no `@` (not a scoped URN)
+    /// - the NSS contains more than one `@` (ambiguous)
+    /// - the part before `@` is empty (`urn:product:@catalog:that`)
+    /// - the part after `@` has no `:` (`urn:product:sku@catalog`)
+    /// - the scope NID or scope NSS is empty (`urn:product:sku@:nss` / `urn:product:sku@nid:`)
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // urn:product:sku123@catalog:that  →  CatalogUrn(urn:catalog:that)
+    /// let scope: CatalogUrn = scoped_product.extract_scope::<CatalogUrn>()?;
+    /// ```
+    fn extract_scope<O>(&self) -> crate::Result<O>
+    where
+        O: TryFrom<Urn, Error: std::fmt::Debug>,
+    {
+        let current_urn: Urn = self.get_id().clone().into();
+        let nss = current_urn.nss();
+
+        let at_count = nss.chars().filter(|&c| c == '@').count();
+        if at_count == 0 {
+            return Err(Error::invalid_input("URN is not scoped (no '@' in NSS)")
+                .with_operation("extract_scope")
+                .with_context("urn", current_urn.to_string()));
+        }
+        if at_count > 1 {
+            return Err(
+                Error::invalid_input("URN has multiple '@' in NSS (ambiguous scope)")
+                    .with_operation("extract_scope")
+                    .with_context("urn", current_urn.to_string()),
+            );
+        }
+
+        // exactly one '@'
+        let (own_nss, scope_part) = nss.split_once('@').unwrap();
+
+        if own_nss.is_empty() {
+            return Err(Error::invalid_input("URN has empty NSS before '@'")
+                .with_operation("extract_scope")
+                .with_context("urn", current_urn.to_string()));
+        }
+
+        let (scope_nid, scope_nss) = scope_part.split_once(':').ok_or_else(|| {
+            Error::invalid_input("Scope part after '@' is missing ':' (expected '<nid>:<nss>')")
+                .with_operation("extract_scope")
+                .with_context("urn", current_urn.to_string())
+                .with_context("scope_part", scope_part.to_string())
+        })?;
+
+        if scope_nid.is_empty() {
+            return Err(Error::invalid_input("Scope NID is empty")
+                .with_operation("extract_scope")
+                .with_context("urn", current_urn.to_string()));
+        }
+        if scope_nss.is_empty() {
+            return Err(Error::invalid_input("Scope NSS is empty")
+                .with_operation("extract_scope")
+                .with_context("urn", current_urn.to_string()));
+        }
+
+        let scope_urn = urn::UrnBuilder::new(scope_nid, scope_nss)
+            .build()
+            .map_err(|e| {
+                Error::invalid_input("Failed to build scope URN")
+                    .with_operation("extract_scope")
+                    .with_context("scope_nid", scope_nid.to_string())
+                    .with_context("scope_nss", scope_nss.to_string())
+                    .with_context("error", format!("{:?}", e))
+            })?;
+
+        O::try_from(scope_urn).map_err(|e| {
+            Error::invalid_input("Failed to convert scope URN to expected type (NID mismatch?)")
+                .with_operation("extract_scope")
+                .with_context("error", format!("{:?}", e))
+        })
+    }
 }
 
 /// In event sourcing a stream is a sequence of events that are related to a specific entity.
@@ -266,5 +403,190 @@ mod tests {
         bank_account.apply(withdrawn_event);
 
         assert_eq!(bank_account.balance, 50.0);
+    }
+
+    // product urn — validates nid == "product"
+    #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+    struct ProductUrn(Urn);
+
+    impl From<ProductUrn> for Urn {
+        fn from(urn: ProductUrn) -> Self {
+            urn.0
+        }
+    }
+
+    impl TryFrom<Urn> for ProductUrn {
+        type Error = String;
+
+        fn try_from(urn: Urn) -> Result<Self, Self::Error> {
+            if urn.nid() == "product" {
+                Ok(ProductUrn(urn))
+            } else {
+                Err(format!(
+                    "Invalid NID for ProductUrn: expected 'product', got '{}'",
+                    urn.nid()
+                ))
+            }
+        }
+    }
+
+    // catalog urn — validates nid == "catalog"
+    #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+    struct CatalogUrn(Urn);
+
+    impl From<CatalogUrn> for Urn {
+        fn from(urn: CatalogUrn) -> Self {
+            urn.0
+        }
+    }
+
+    impl TryFrom<Urn> for CatalogUrn {
+        type Error = String;
+
+        fn try_from(urn: Urn) -> Result<Self, Self::Error> {
+            if urn.nid() == "catalog" {
+                Ok(CatalogUrn(urn))
+            } else {
+                Err(format!(
+                    "Invalid NID for CatalogUrn: expected 'catalog', got '{}'",
+                    urn.nid()
+                ))
+            }
+        }
+    }
+
+    // minimal stream wrappers so we can call WithId methods
+    struct ProductStream {
+        pub id: ProductUrn,
+    }
+
+    impl WithId for ProductStream {
+        type StreamId = ProductUrn;
+
+        fn with_id(id: Self::StreamId) -> Self {
+            ProductStream { id }
+        }
+
+        fn get_id(&self) -> &Self::StreamId {
+            &self.id
+        }
+    }
+
+    #[test]
+    fn test_at_creates_scoped_urn() {
+        let product = ProductStream::with_string_id("urn:product:sku123").unwrap();
+        let catalog = CatalogUrn(Urn::from_str("urn:catalog:that").unwrap());
+        let scoped = product.at(catalog).unwrap();
+        let scoped_urn: Urn = scoped.get_id().clone().into();
+        assert_eq!(scoped_urn.to_string(), "urn:product:sku123@catalog:that");
+    }
+
+    #[test]
+    fn test_at_fails_if_already_scoped() {
+        let product = ProductStream::with_string_id("urn:product:sku123@catalog:that").unwrap();
+        let catalog = CatalogUrn(Urn::from_str("urn:catalog:other").unwrap());
+        assert!(product.at(catalog).is_err());
+    }
+
+    #[test]
+    fn test_extract_scope_happy_path() {
+        let product = ProductStream::with_string_id("urn:product:sku123@catalog:that").unwrap();
+        let scope: CatalogUrn = product.extract_scope::<CatalogUrn>().unwrap();
+        let scope_urn: Urn = scope.into();
+        assert_eq!(scope_urn.nid(), "catalog");
+        assert_eq!(scope_urn.nss(), "that");
+    }
+
+    #[test]
+    fn test_extract_scope_wrong_nid_fails() {
+        // The scope is urn:catalog:that, but we ask for it as ProductUrn (nid="product").
+        let product = ProductStream::with_string_id("urn:product:sku123@catalog:that").unwrap();
+        let err = product.extract_scope::<ProductUrn>().unwrap_err();
+        assert!(err.to_string().contains("NID mismatch"));
+    }
+
+    #[test]
+    fn test_extract_scope_roundtrip() {
+        let product = ProductStream::with_string_id("urn:product:sku123").unwrap();
+        let catalog = CatalogUrn(Urn::from_str("urn:catalog:that").unwrap());
+        let scoped = product.at(catalog.clone()).unwrap();
+        let extracted: CatalogUrn = scoped.extract_scope::<CatalogUrn>().unwrap();
+        assert_eq!(extracted, catalog);
+    }
+
+    #[test]
+    fn test_extract_scope_not_scoped() {
+        let product = ProductStream::with_string_id("urn:product:sku123").unwrap();
+        let err = product.extract_scope::<CatalogUrn>().unwrap_err();
+        assert!(err.to_string().contains("not scoped"));
+    }
+
+    #[test]
+    fn test_extract_scope_empty_own_nss() {
+        // urn:product:@catalog:that — empty NSS before @
+        let product = ProductStream::with_string_id("urn:product:@catalog:that").unwrap();
+        let err = product.extract_scope::<CatalogUrn>().unwrap_err();
+        assert!(err.to_string().contains("empty NSS before"));
+    }
+
+    #[test]
+    fn test_extract_scope_missing_colon_in_scope() {
+        // urn:product:sku123@catalog — no colon after @
+        let product = ProductStream::with_string_id("urn:product:sku123@catalog").unwrap();
+        let err = product.extract_scope::<CatalogUrn>().unwrap_err();
+        assert!(err.to_string().contains("missing ':'"));
+    }
+
+    #[test]
+    fn test_extract_scope_multiple_at() {
+        // urn:product:sku123@catalog:that@tenant:acme — multiple @
+        let product =
+            ProductStream::with_string_id("urn:product:sku123@catalog:that@tenant:acme").unwrap();
+        let err = product.extract_scope::<CatalogUrn>().unwrap_err();
+        assert!(err.to_string().contains("multiple '@'"));
+    }
+
+    #[test]
+    fn test_at_preserves_own_nid_and_nss() {
+        // The base product's nid and the NSS before @ must be unchanged.
+        let product = ProductStream::with_string_id("urn:product:sku-999").unwrap();
+        let catalog = CatalogUrn(Urn::from_str("urn:catalog:books").unwrap());
+        let scoped = product.at(catalog).unwrap();
+        let scoped_urn: Urn = scoped.get_id().clone().into();
+        assert_eq!(scoped_urn.nid(), "product");
+        assert_eq!(scoped_urn.nss(), "sku-999@catalog:books");
+    }
+
+    #[test]
+    fn test_extract_scope_empty_scope_nid() {
+        // urn:product:sku@:nss — empty NID in scope
+        let product = ProductStream::with_string_id("urn:product:sku@:nss").unwrap();
+        let err = product.extract_scope::<CatalogUrn>().unwrap_err();
+        assert!(err.to_string().contains("Scope NID is empty"));
+    }
+
+    #[test]
+    fn test_extract_scope_empty_scope_nss() {
+        // urn:product:sku@nid: — empty NSS in scope
+        let product = ProductStream::with_string_id("urn:product:sku@nid:").unwrap();
+        let err = product.extract_scope::<CatalogUrn>().unwrap_err();
+        assert!(err.to_string().contains("Scope NSS is empty"));
+    }
+
+    #[test]
+    fn test_scoped_urn_parses_back_from_string() {
+        // A scoped URN should survive a round-trip through with_string_id.
+        let product = ProductStream::with_string_id("urn:product:sku123").unwrap();
+        let catalog = CatalogUrn(Urn::from_str("urn:catalog:that").unwrap());
+        let scoped_urn_str: String = {
+            let u: Urn = product.at(catalog).unwrap().get_id().clone().into();
+            u.to_string()
+        };
+        // Parse back from the URN string.
+        let reparsed = ProductStream::with_string_id(&scoped_urn_str).unwrap();
+        let scope: CatalogUrn = reparsed.extract_scope::<CatalogUrn>().unwrap();
+        let scope_urn: Urn = scope.into();
+        assert_eq!(scope_urn.nid(), "catalog");
+        assert_eq!(scope_urn.nss(), "that");
     }
 }

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -574,3 +574,129 @@ async fn bank_account_compaction_postgres_test() {
         "Archived Version(1) must retain all 6 original events"
     );
 }
+
+// ── Scoped-URN types used by the tests below ─────────────────────────────────
+
+/// A branch that owns one or more bank accounts.
+#[derive(Clone, Serialize, Deserialize, Debug, Urn)]
+struct BranchUrn(Urn);
+
+impl TryFrom<Urn> for BranchUrn {
+    type Error = String;
+
+    fn try_from(urn: Urn) -> Result<Self, Self::Error> {
+        let expected_nid = "branch";
+        if urn.nid() == expected_nid {
+            Ok(BranchUrn(urn))
+        } else {
+            Err(format!(
+                "Invalid namespace for BranchUrn: expected '{}', found '{}'",
+                expected_nid,
+                urn.nid()
+            ))
+        }
+    }
+}
+
+/// Minimal stream wrapper that uses `BankAccountUrn` as its `StreamId`.
+/// Used for `at` / `extract_scope` tests without Postgres.
+#[derive(Debug)]
+struct BankAccountStream {
+    pub id: BankAccountUrn,
+}
+
+impl WithId for BankAccountStream {
+    type StreamId = BankAccountUrn;
+
+    fn with_id(id: Self::StreamId) -> Self {
+        BankAccountStream { id }
+    }
+
+    fn get_id(&self) -> &Self::StreamId {
+        &self.id
+    }
+}
+
+// ── Scoped-URN tests (no Postgres required) ───────────────────────────────────
+
+/// A bank-account URN can be scoped to a branch:
+///   urn:bank-account:acct-1  +  urn:branch:london  →  urn:bank-account:acct-1@branch:london
+#[test]
+fn test_bank_account_scoped_to_branch() {
+    let account = BankAccountStream::with_string_id("urn:bank-account:acct-1").unwrap();
+    let branch = BranchUrn(UrnBuilder::new("branch", "london").build().unwrap());
+
+    let scoped = account.at(branch).unwrap();
+    let scoped_urn: Urn = scoped.get_id().clone().into();
+
+    assert_eq!(
+        scoped_urn.to_string(),
+        "urn:bank-account:acct-1@branch:london"
+    );
+    assert_eq!(scoped_urn.nid(), "bank-account");
+    assert_eq!(scoped_urn.nss(), "acct-1@branch:london");
+}
+
+/// Extracting the scope as `BranchUrn` validates the NID is "branch".
+#[test]
+fn test_extract_branch_from_scoped_account() {
+    let scoped =
+        BankAccountStream::with_string_id("urn:bank-account:acct-1@branch:london").unwrap();
+
+    let branch: BranchUrn = scoped.extract_scope::<BranchUrn>().unwrap();
+
+    assert_eq!(branch.0.nid(), "branch");
+    assert_eq!(branch.0.nss(), "london");
+}
+
+/// Extracting with the wrong type fails because the NID doesn't match.
+#[test]
+fn test_extract_scope_wrong_nid_fails() {
+    // scope is urn:branch:london, but we ask for BankAccountUrn (nid="bank-account")
+    let scoped =
+        BankAccountStream::with_string_id("urn:bank-account:acct-1@branch:london").unwrap();
+    let err = scoped.extract_scope::<BankAccountUrn>().unwrap_err();
+    assert!(err.to_string().contains("NID mismatch"));
+}
+
+/// `at` followed by `extract_scope` must round-trip to the original scope URN.
+#[test]
+fn test_scope_round_trip() {
+    let account = BankAccountStream::with_string_id("urn:bank-account:acct-42").unwrap();
+    let branch = BranchUrn(UrnBuilder::new("branch", "paris").build().unwrap());
+
+    let scoped = account.at(branch.clone()).unwrap();
+    let extracted: BranchUrn = scoped.extract_scope::<BranchUrn>().unwrap();
+
+    assert_eq!(extracted, branch);
+}
+
+/// Attempting to scope an already-scoped stream must fail.
+#[test]
+fn test_cannot_double_scope_account() {
+    let scoped =
+        BankAccountStream::with_string_id("urn:bank-account:acct-1@branch:london").unwrap();
+    let another_branch = BranchUrn(UrnBuilder::new("branch", "berlin").build().unwrap());
+
+    let err = scoped.at(another_branch).unwrap_err();
+    assert!(err.to_string().contains("already scoped"));
+}
+
+/// A scoped URN survives serialisation to a string and back.
+#[test]
+fn test_scoped_urn_string_round_trip() {
+    let account = BankAccountStream::with_string_id("urn:bank-account:acct-7").unwrap();
+    let branch = BranchUrn(UrnBuilder::new("branch", "tokyo").build().unwrap());
+    let scoped_str: String = {
+        let u: Urn = account.at(branch).unwrap().get_id().clone().into();
+        u.to_string()
+    };
+
+    assert_eq!(scoped_str, "urn:bank-account:acct-7@branch:tokyo");
+
+    // Reconstruct from the string and extract scope as the typed BranchUrn.
+    let reparsed = BankAccountStream::with_string_id(&scoped_str).unwrap();
+    let branch: BranchUrn = reparsed.extract_scope::<BranchUrn>().unwrap();
+    assert_eq!(branch.0.nid(), "branch");
+    assert_eq!(branch.0.nss(), "tokyo");
+}


### PR DESCRIPTION
## Summary

Adds two new default methods to the `WithId` trait for composing and decomposing scoped URNs.

### `at(other: impl Into<Urn>) -> Result<Self>`

Scopes a stream ID under another by appending `@<nid>:<nss>` to the NSS:

```rust
let scoped = product.at(catalog_id)?;
// urn:product:sku123  →  urn:product:sku123@catalog:that
```

Fails if the URN is already scoped (contains `@`).

### `extract_scope<O>() -> Result<O>`

Extracts the embedded scope URN and converts it to the caller-specified type `O` via `TryFrom<Urn>`, which enforces NID validation:

```rust
let catalog: CatalogUrn = scoped_product.extract_scope::<CatalogUrn>()?;

// Wrong type → fails with NID mismatch error
let wrong: ProductUrn = scoped_product.extract_scope::<ProductUrn>()?; // err
```

### Validation

| Condition | Error |
|---|---|
| NSS already contains `@` | `at`: already scoped |
| No `@` in NSS | `extract_scope`: not scoped |
| Empty NSS before `@` | `extract_scope`: empty NSS before '@' |
| No `:' after `@` | `extract_scope`: missing ':' |
| Empty scope NID or NSS | `extract_scope`: Scope NID/NSS is empty |
| Multiple `@` | `extract_scope`: multiple '@' (ambiguous) |
| Wrong output type | `extract_scope`: NID mismatch |

## Changes

- `es/src/stream.rs`: new `at` and `extract_scope` methods on `WithId`, unit tests with `ProductUrn`/`CatalogUrn` (NID-validated)
- `persistence/tests/integration_tests.rs`: integration tests with `BankAccountUrn` scoped to `BranchUrn`
- `README.md`: new "Composing Scoped URNs" section with examples and validation table