### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["es", "macros", "persistence", "macros-tests"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Carlos Verdes <cverdes@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps the workspace version from `0.1.1` to `0.1.2` to publish the following changes that were merged since the last release:

- **#48** `feat: add scoped URN composition via WithId::at and extract_scope`
- **#49** `feat: ScopedUrn trait, prelude, define_aggregate! integration tests, WASM fix`
- **#50** `docs: document all StreamFilter options with examples`

All workspace tests pass.
