### PR TITLE
fix: return Result<Vec<Self::Event>, Self::Error> from Aggregate::handle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["es", "macros", "persistence", "macros-tests"]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = ["Carlos Verdes <cverdes@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["es", "macros", "persistence", "macros-tests"]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Carlos Verdes <cverdes@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_with = "3.18.0"
+serde_with = "3.20.0"
 serde_json = "1.0.149"
 
 urn = { version = "0.7.0", features = ["serde"] }
@@ -36,7 +36,7 @@ sqlx = { version = "0.8.6", features = [
   "postgres",
 ] }
 
-tokio = { version = "1.52.1", features = ["full"] }
+tokio = { version = "1.52", features = ["full"] }
 futures = "0.3.31"
 async-stream = "0.3.6"
 async-trait = "0.1"

--- a/es/src/aggregate.rs
+++ b/es/src/aggregate.rs
@@ -39,13 +39,13 @@ pub trait Aggregate: Sync + Send + EventStream {
         &self,
         command: Self::Command,
         services: &Self::Services,
-    ) -> impl Future<Output = crate::Result<Vec<Self::Event>>> + Send;
+    ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send;
 
     fn handle_and_apply<'a>(
         &'a mut self,
         command: Self::Command,
         services: &'a Self::Services,
-    ) -> impl Future<Output = crate::Result<Vec<Self::Event>>> + Send + 'a
+    ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send + 'a
     where
         Self: Sized,
     {
@@ -89,13 +89,13 @@ pub trait Aggregate: Sync + EventStream {
         &self,
         command: Self::Command,
         services: &Self::Services,
-    ) -> impl Future<Output = crate::Result<Vec<Self::Event>>>;
+    ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>>;
 
     fn handle_and_apply<'a>(
         &'a mut self,
         command: Self::Command,
         services: &'a Self::Services,
-    ) -> impl Future<Output = crate::Result<Vec<Self::Event>>> + 'a
+    ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + 'a
     where
         Self: Sized,
     {

--- a/macros-tests/Cargo.toml
+++ b/macros-tests/Cargo.toml
@@ -12,8 +12,8 @@ readme.workspace = true
 name = "replay_macros_tests"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.1.3" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.1.3" }
+replay = { package = "es-replay", path = "../es", version = "0.1.4" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.1.4" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/macros-tests/Cargo.toml
+++ b/macros-tests/Cargo.toml
@@ -12,8 +12,8 @@ readme.workspace = true
 name = "replay_macros_tests"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.1.4" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.1.4" }
+replay = { package = "es-replay", path = "../es", version = "0.2.0" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.2.0" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/macros-tests/tests/aggregate_macro_test.rs
+++ b/macros-tests/tests/aggregate_macro_test.rs
@@ -73,7 +73,7 @@ impl Aggregate for BankAccount {
         &self,
         command: Self::Command,
         services: &Self::Services,
-    ) -> replay::Result<Vec<Self::Event>> {
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             BankAccountCommand::OpenAccount { account_number } => {
                 if !services.validate_account_number(&account_number).await {
@@ -914,7 +914,7 @@ mod tests {
                 &self,
                 command: Self::Command,
                 _services: &Self::Services,
-            ) -> replay::Result<Vec<Self::Event>> {
+            ) -> Result<Vec<Self::Event>, Self::Error> {
                 match command {
                     ManagerCommand::Update { thing } => Ok(vec![ManagerEvent::Updated { thing }]),
                 }
@@ -1007,7 +1007,7 @@ mod tests {
                 &self,
                 command: Self::Command,
                 _services: &Self::Services,
-            ) -> replay::Result<Vec<Self::Event>> {
+            ) -> Result<Vec<Self::Event>, Self::Error> {
                 match command {
                     ProcessorCommand::Process { item } => {
                         // item is T::Item which is String
@@ -1109,7 +1109,7 @@ mod tests {
                 &self,
                 command: Self::Command,
                 _services: &Self::Services,
-            ) -> replay::Result<Vec<Self::Event>> {
+            ) -> Result<Vec<Self::Event>, Self::Error> {
                 match command {
                     FileProcessorCommand::ProcessBytes { mut reader } => {
                         // Process the byte stream
@@ -1191,7 +1191,7 @@ mod tests {
                 &self,
                 command: Self::Command,
                 _services: &Self::Services,
-            ) -> replay::Result<Vec<Self::Event>> {
+            ) -> Result<Vec<Self::Event>, Self::Error> {
                 match command {
                     StreamProcessorCommand::ProcessStream { receiver } => {
                         let mut count = 0;

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 name = "replay_macros"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.1.4" }
+replay = { package = "es-replay", path = "../es", version = "0.2.0" }
 proc-macro2 = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 name = "replay_macros"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.1.3" }
+replay = { package = "es-replay", path = "../es", version = "0.1.4" }
 proc-macro2 = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }

--- a/persistence/Cargo.toml
+++ b/persistence/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["lib"]
 name = "replay_persistence"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.1.3" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.1.3" }
+replay = { package = "es-replay", path = "../es", version = "0.1.4" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.1.4" }
 
 serde = { workspace = true }
 serde_with = { workspace = true }

--- a/persistence/Cargo.toml
+++ b/persistence/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["lib"]
 name = "replay_persistence"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.1.4" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.1.4" }
+replay = { package = "es-replay", path = "../es", version = "0.2.0" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.2.0" }
 
 serde = { workspace = true }
 serde_with = { workspace = true }

--- a/persistence/src/infrastructure/in_memory_store.rs
+++ b/persistence/src/infrastructure/in_memory_store.rs
@@ -363,7 +363,7 @@ mod tests {
             &self,
             _command: Self::Command,
             _services: &Self::Services,
-        ) -> replay::Result<Vec<Self::Event>> {
+        ) -> Result<Vec<Self::Event>, Self::Error> {
             Ok(vec![])
         }
     }

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -79,7 +79,7 @@ impl replay::Aggregate for BankAccount {
         &self,
         command: Self::Command,
         _services: &Self::Services,
-    ) -> replay::Result<Vec<Self::Event>> {
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             BankAccountCommand::Deposit {
                 effective_on,


### PR DESCRIPTION
The `Aggregate` trait defines a custom `type Error`, but `handle` was hardcoded to return `crate::Result` (i.e. `Result<_, replay::Error>`), ignoring the user-defined error type.\n\nThis PR changes the return type of `handle` and `handle_and_apply` to `Result<Vec<Self::Event>, Self::Error>` on both the non-WASM and WASM trait variants, and updates all implementations accordingly.