### PR TITLE
feat(persistence): inline projections walking skeleton (#58)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Conventions
+
+## PR Titles and Squash Merge
+
+This repository uses squash merge as the default merge strategy.
+
+Rule:
+- The pull request title MUST follow Conventional Commits format, because the squash commit message is derived from the PR title.
+
+Use:
+- `type(scope): short summary`
+
+Examples:
+- `feat(persistence): inline projections walking skeleton`
+- `fix(es): prevent duplicate event application`
+- `docs(readme): clarify wasm test command`
+
+Allowed `type` values (recommended):
+- `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+
+Before opening or updating a PR:
+- Ensure the PR title is already in Conventional Commits format.
+- If not, update it with `gh pr edit --title "type(scope): ..."`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,6 +49,22 @@ Discarding a projection's current state (reset) and replaying the full event
 history through it to reconstruct it. Triggered when a projection's code version
 is newer than the version recorded in the store.
 
+### WASM target
+
+`replay` supports WebAssembly. The core `es` crate and the `macros` crate are
+WASM-compatible: they provide **dual, cfg-gated definitions** of the core traits —
+`Send`-bounded under `cfg(not(target_arch = "wasm32"))` for multi-threaded native
+runtimes, and `Send`-free under `cfg(target_arch = "wasm32")` for the
+single-threaded WASM environment (generated services use
+`cfg_attr(target_arch = "wasm32", async_trait(?Send))`). Any change to traits in
+`es`/`macros` must preserve both arms. The `persistence` crate (Postgres + sqlx +
+tokio) is **server-only / non-WASM**, so every projection mechanism that lives
+there — including the [Inline projection] — is a native-only feature and is free
+to use `Send` bounds. A future [Async projection] aimed at client/edge targets
+would need to honour the WASM dual-cfg pattern.
+
 [Aggregate]: #aggregate
 [Query]: #query
 [Live projection]: #live-projection
+[Inline projection]: #inline-projection
+[Async projection]: #async-projection

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,54 @@
+# Context: replay
+
+The ubiquitous language for the `replay` event-sourcing library.
+
+## Glossary
+
+### Projection
+
+An umbrella term for a derived read model built from events. "Projection" on its
+own never names a single mechanism — always qualify it as a Live, Inline, or
+Async projection. Distinct from an [Aggregate], which is the write-side state
+rebuilt from a stream to make command decisions.
+
+### Live projection
+
+A read model computed on demand by folding events in memory, without persisting
+any state or progress. This is the existing [Query] mechanism. The caller drives
+it; nothing is stored between runs.
+
+### Inline projection
+
+A projection whose write is applied **inside the same transaction that appends
+the events**, against the **same event store instance**. It is strongly
+consistent with the events: the events and the projection write commit together
+or not at all. The projection does not begin or commit the transaction — it only
+contributes writes to a transaction the store owns.
+
+### Async projection
+
+A projection that updates an **external** system (for example a search index)
+**eventually**, decoupled from the append transaction, driven by a background
+process that compares projection progress against the event stream. Eventually
+consistent rather than strongly consistent. (Planned; not yet implemented.)
+
+### Query
+
+The existing on-demand, in-memory fold over filtered events. It is the
+realisation of a [Live projection].
+
+### Projection version
+
+A number declared in projection code that identifies the shape/logic of a
+projection. When the version recorded in the store is older than the version in
+code, the projection is rebuilt: its state is reset and all events are replayed.
+
+### Rebuild
+
+Discarding a projection's current state (reset) and replaying the full event
+history through it to reconstruct it. Triggered when a projection's code version
+is newer than the version recorded in the store.
+
+[Aggregate]: #aggregate
+[Query]: #query
+[Live projection]: #live-projection

--- a/README.md
+++ b/README.md
@@ -1036,6 +1036,8 @@ use replay_persistence::prelude::*;
 | `EventStore` | Trait for pluggable event store backends |
 | `InMemoryEventStore` | In-memory backend (testing) |
 | `PostgresEventStore` | PostgreSQL backend |
+| `InlineProjection` | Trait for inline read-model projections |
+| `PostgresInlineProjection` | Postgres-specific inline projection marker trait |
 | `PersistedEvent` | Wrapper holding an event with its metadata |
 | `Query` | Trait for read-model projections |
 | `StreamFilter` | Filter builder for event queries |
@@ -1261,6 +1263,119 @@ let filter = StreamFilter::for_stream_type::<BankAccountStream>()
 
 let events = store.stream_events::<BankAccountEvent>(filter);
 ```
+
+## Inline Projections (Postgres)
+
+`Query` gives you a **live** read model: it folds events in memory when you ask for it.
+
+An **inline projection** is different: it persists a read model inside the same Postgres
+transaction that appends the events. That means the event append and the projection write
+commit together or not at all.
+
+### When to use it
+
+Use an inline projection when:
+
+- the read model lives in the same Postgres datastore as the event store
+- the projection table/indexes are managed by normal SQL migrations
+- on each event batch you just want to execute SQL against that table
+
+### Migrations
+
+There are two migration concerns:
+
+1. **Your projection schema**: create the projection table/indexes in your own SQL migrations.
+2. **Replay projection metadata**: ensure the `projections` registry table exists.
+
+The registry table tracks projection `name()` and `version()`:
+
+```sql
+CREATE TABLE IF NOT EXISTS projections (
+    name        TEXT                        NOT NULL PRIMARY KEY,
+    version     INTEGER                     NOT NULL,
+    updated_at  TIMESTAMP WITH TIME ZONE    NOT NULL DEFAULT (now())
+);
+```
+
+`append_event` should also return the persisted event metadata used by inline projections
+(`id`, `version`, `created`) so the store can build `PersistedEvent`s without a second
+read-back query.
+
+### Lowest-ceremony path: register a Postgres event handler
+
+If your schema is already created by migrations, the simplest API is
+`register_postgres_event_handler(...)`. You provide:
+
+- a stable projection name
+- a projection version
+- a closure that receives `&mut sqlx::PgConnection` and the matching persisted events
+
+```rust
+use futures::future::BoxFuture;
+use replay_persistence::{Cqrs, PostgresEventStore, PersistedEvent};
+
+// Example event type from your aggregate
+use crate::BankAccountEvent;
+
+let store = PostgresEventStore::builder(pg_pool.clone())
+    .register_postgres_event_handler::<BankAccountEvent, _>(
+        "account_balance_view",
+        1,
+        |conn, events| {
+            Box::pin(async move {
+                for event in events {
+                    let delta = match &event.data {
+                        BankAccountEvent::Deposited { amount, .. } => *amount,
+                        BankAccountEvent::Withdrawn { amount, .. } => -*amount,
+                        BankAccountEvent::MonthlyClosed { .. } => continue,
+                    };
+
+                    sqlx::query(
+                        "INSERT INTO account_balances (stream_id, balance)
+                         VALUES ($1, $2)
+                         ON CONFLICT (stream_id)
+                         DO UPDATE SET balance = account_balances.balance + EXCLUDED.balance",
+                    )
+                    .bind(event.stream_id.to_string())
+                    .bind(delta)
+                    .execute(&mut *conn)
+                    .await?;
+                }
+
+                Ok(())
+            })
+        },
+    )
+    .build()
+    .await?;
+
+let cqrs = Cqrs::new(store);
+```
+
+This helper assumes:
+
+- the projection table already exists
+- `init` is a no-op
+- the only runtime work is "run SQL for this batch of events"
+
+### Full control: implement `InlineProjection`
+
+If you need more control, implement `InlineProjection` directly. This is useful when you want a
+named type, custom `init`, or more involved logic than a single handler closure.
+
+`PostgresInlineProjection` is also re-exported as a Postgres-specific marker for this case.
+
+### Runtime behavior
+
+- `PostgresEventStore::builder(...).build().await?` runs first-time projection setup and records
+  the current version in the `projections` table.
+- On each successful append, the store constructs `PersistedEvent`s from the metadata returned by
+  `append_event(...)` and passes them to every registered projection.
+- Projection handlers run inside the **same Postgres transaction** as the event append.
+- If a projection handler returns an error, the whole append rolls back.
+
+Inline projections are Postgres-only. The in-memory store remains useful for tests, but the
+transactional guarantee belongs to the Postgres backend.
 
 ## Querying Events from Multiple Aggregates
 

--- a/docs/adr/0001-inline-projection-architecture.md
+++ b/docs/adr/0001-inline-projection-architecture.md
@@ -1,0 +1,50 @@
+# Inline projections run atomically inside the append transaction and are store-specific
+
+**Status:** accepted
+
+We add a first kind of persisted read-model projection — the *inline projection* —
+whose write is applied **inside the same transaction that appends the events**,
+against the **same event store instance**. The projection loop lives inside
+`EventStore::store_events`: after appending a command's events the store offers
+them to each registered projection and only commits if every projection's
+`handle` succeeds; any error rolls the whole transaction back. This makes a
+projection and the events it derives from strongly consistent — they commit
+together or not at all — and means a projection is never behind the log, so no
+checkpoint or catch-up position is ever stored (the `projections` table records
+only a version, for rebuild detection).
+
+The registry of projections is **fixed at construction** via a builder
+(`PostgresEventStore::builder(pool).register(..).build().await?`). `build()` runs
+each projection's `init` / version-drift check / replay once at startup and then
+freezes the set, so the append hot path reads it lock-free and projections can
+never appear or rebuild under live traffic. On version drift the projection is
+reset and all (filtered) events are replayed in a single transaction with the new
+version written last; a stored version *newer* than the code version is a hard
+error (a likely bad/rolled-back deploy) rather than a silent backward rebuild.
+
+## Considered options
+
+- **Store-agnostic inline projections** (associated transaction/executor type on
+  the `EventStore` trait, or a generic write-port abstraction). Rejected: it
+  leaks `sqlx` transaction lifetimes into a public generic trait (GAT pain),
+  forces the in-memory store to model a transaction it lacks, and the generic
+  write API just re-exposes SQL through a leaky abstraction. Inline projections
+  are treated as an extension of a concrete store instead; the in-memory store
+  runs them best-effort for tests, but true atomicity is a Postgres guarantee.
+- **After-commit, best-effort handling** (projection writes through its own
+  connection after the events commit). Rejected for the primary use case: it has
+  a real correctness hole (event committed, projection write lost, never
+  reconciled because rebuilds only fire on version drift). This eventual,
+  external-target model is deferred to a future *async projection*.
+- **Runtime registration on a live store** (lock-guarded registry, async
+  `register_projection`). Rejected: projection versions only change on recompile,
+  so all upgrade/replay work belongs at startup; freezing the set removes hot-path
+  locking and the possibility of projections changing under load.
+
+## Consequences
+
+- Inline projections require Postgres; the in-memory store supports them only
+  best-effort for testing.
+- `store_events` gains a second responsibility (append + project) and
+  `PostgresEventStore` becomes stateful beyond its pool, but the write path stays
+  single so projections can't be accidentally bypassed.

--- a/docs/adr/0001-inline-projection-architecture.md
+++ b/docs/adr/0001-inline-projection-architecture.md
@@ -48,3 +48,10 @@ error (a likely bad/rolled-back deploy) rather than a silent backward rebuild.
 - `store_events` gains a second responsibility (append + project) and
   `PostgresEventStore` becomes stateful beyond its pool, but the write path stays
   single so projections can't be accidentally bypassed.
+- Inline projections are **native-only (non-WASM)**. They live in the
+  `persistence` crate, which depends on `sqlx`/`tokio`/Postgres and does not
+  target `wasm32`, so the `InlineProjection` trait is free to use `Send` bounds
+  and `BoxFuture`. WASM consumers use the core `es`/`macros` crates (which keep
+  their dual `cfg(target_arch = "wasm32")` trait arms) for the write side; a
+  WASM-facing read model would be served by the future *async projection*, which
+  must honour the no-`Send` WASM pattern.

--- a/docs/adr/0002-projection-event-routing.md
+++ b/docs/adr/0002-projection-event-routing.md
@@ -30,3 +30,7 @@ so the `query_events!` machinery is reused rather than reinvented.
   per append. Negligible at catalog write volumes; if it ever matters, projections
   can be pre-indexed by `event_type` or the planned in-memory `StreamFilter`
   evaluation can pre-filter before deserialization.
+- This routing lives in the native-only `persistence` crate, so the erased
+  wrapper and its `BoxFuture`/`Send` bounds are fine. The `query_events!` macro it
+  reuses is itself WASM-compatible (it lives in `macros`); reusing it here does
+  not change that — only the Postgres-side routing is native-only.

--- a/docs/adr/0002-projection-event-routing.md
+++ b/docs/adr/0002-projection-event-routing.md
@@ -1,0 +1,32 @@
+# Projection event routing by deserialize-or-skip over JSON
+
+**Status:** accepted
+
+Inline projections declare their consumed events as a `query_events!`-merged enum
+(`type Event`), exactly like the existing live `Query`, and the store routes
+events to them by **attempting to deserialize and skipping on failure**. On append,
+each event is serialized to `serde_json::Value` (the store serializes to JSON for
+storage anyway) and the batch is offered to every registered projection; the
+internal erased wrapper deserializes the batch into `Vec<PersistedEvent<P::Event>>`,
+dropping events that aren't one of the projection's types, and calls the typed
+`handle` once with whatever remains (skipping the projection entirely if nothing
+matches). This lets the store hold a heterogeneous `Vec` of projections without
+naming each one's event type, and keeps inline projections symmetric with `Query`
+so the `query_events!` machinery is reused rather than reinvented.
+
+## Considered options
+
+- **Type-keyed dispatch** via an associated `Source: EventStream`, routing by
+  `stream_type`. Rejected for now: exact and cheaper on the hot path, but it
+  diverges from the `Query` authoring model and adds trait surface; the chosen
+  approach reuses proven code and stays uniform with live queries.
+
+## Consequences
+
+- Routing is by JSON *shape*: two aggregates with structurally compatible event
+  payloads could in principle mis-route. Event enums are externally tagged by
+  variant name, so collisions are unlikely; revisit if it bites.
+- Each registered projection pays a `from_value` attempt (with a `Value` clone)
+  per append. Negligible at catalog write volumes; if it ever matters, projections
+  can be pre-indexed by `event_type` or the planned in-memory `StreamFilter`
+  evaluation can pre-filter before deserialization.

--- a/persistence/src/infrastructure/mod.rs
+++ b/persistence/src/infrastructure/mod.rs
@@ -2,4 +2,4 @@ mod in_memory_store;
 mod postgres;
 
 pub use in_memory_store::InMemoryEventStore;
-pub use postgres::PostgresEventStore;
+pub use postgres::{PostgresEventStore, PostgresInlineProjection};

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -19,7 +19,7 @@ use replay::{Compactable, Event, Metadata};
 
 /// A registered inline projection, guarded by a mutex so its `&mut self`
 /// `handle`/`init` methods can be driven through the shared (`&self`) store.
-type RegisteredProjection = Mutex<Box<dyn ErasedInlineProjection>>;
+type RegisteredProjection = Mutex<Box<dyn ErasedInlineProjection<Exec = sqlx::PgConnection>>>;
 
 pub struct PostgresEventStore {
     pool: Pool<Postgres>,
@@ -132,14 +132,14 @@ impl PostgresEventStore {
 /// [`build`](Self::build) to run first-time `init` and freeze the registry.
 pub struct PostgresEventStoreBuilder {
     pool: Pool<Postgres>,
-    projections: Vec<Box<dyn ErasedInlineProjection>>,
+    projections: Vec<Box<dyn ErasedInlineProjection<Exec = sqlx::PgConnection>>>,
 }
 
 impl PostgresEventStoreBuilder {
     /// Register an inline projection.
     pub fn register<P>(mut self, projection: P) -> Self
     where
-        P: InlineProjection + 'static,
+        P: InlineProjection<Exec = sqlx::PgConnection> + 'static,
     {
         self.projections.push(Box::new(projection));
         self

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -189,6 +189,62 @@ impl PostgresEventStoreBuilder {
     }
 }
 
+impl PostgresEventStore {
+    /// Apply the just-appended events to every registered inline projection, inside the
+    /// store's open transaction.
+    ///
+    /// The DB-assigned `version`/`created` for each appended event are read back (by id)
+    /// so projections receive faithful `PersistedEvent`s. Each projection is locked
+    /// individually and routes the batch by deserialize-or-skip; any projection error
+    /// propagates and rolls back the whole append.
+    async fn apply_projections(
+        &self,
+        conn: &mut sqlx::PgConnection,
+        stream_id: &Urn,
+        metadata: &Metadata,
+        appended: Vec<(Uuid, String, Value)>,
+    ) -> Result<(), replay::Error> {
+        let mut events: Vec<PersistedEvent<Value>> = Vec::with_capacity(appended.len());
+
+        for (id, event_type, data) in appended {
+            let row = sqlx::query("SELECT version, created FROM events WHERE id = $1")
+                .bind(id)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(crate::db_error)?;
+
+            // Absent only when the append did not insert a row (e.g. a concurrency
+            // conflict swallowed by append_event — see follow-up issue). Skip it here.
+            let Some(row) = row else { continue };
+
+            let version: i64 = row.get("version");
+            let created: chrono::DateTime<Utc> = row.get("created");
+
+            events.push(PersistedEvent {
+                id,
+                data,
+                stream_id: stream_id.clone(),
+                r#type: event_type,
+                version,
+                created,
+                metadata: metadata.clone(),
+                aggregate_version: None,
+            });
+        }
+
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        for projection in self.projections.iter() {
+            let mut projection = projection.lock().await;
+            projection.handle(&mut *conn, &events).await?;
+        }
+
+        Ok(())
+    }
+}
+
 impl EventStore for PostgresEventStore {
     async fn store_events<S: replay::EventStream>(
         &self,
@@ -201,13 +257,24 @@ impl EventStore for PostgresEventStore {
         let mut transaction = self.pool.begin().await.map_err(crate::db_error)?;
         let stream_id: Urn = stream_id.clone().into();
 
+        // Track the appended events so registered inline projections can be applied
+        // inside this same transaction. We only retain what's needed to rebuild the
+        // PersistedEvent: the generated id, the JSON payload and the event type.
+        let has_projections = !self.projections.is_empty();
+        let mut appended: Vec<(Uuid, String, Value)> = if has_projections {
+            Vec::with_capacity(domain_events.len())
+        } else {
+            Vec::new()
+        };
+
         for event in domain_events {
             let event_type = event.event_type().clone();
             let event = serde_json::to_value(event).map_err(crate::ser_error)?;
+            let id = Uuid::new_v4();
 
             sqlx::query!(
                 "SELECT append_event($1, $2, $3, $4, $5, $6, $7) ",
-                Uuid::new_v4(),
+                id,
                 event,
                 metadata.to_json(),
                 event_type,
@@ -218,6 +285,15 @@ impl EventStore for PostgresEventStore {
             .fetch_optional(&mut *transaction)
             .await
             .map_err(crate::db_error)?;
+
+            if has_projections {
+                appended.push((id, event_type, event));
+            }
+        }
+
+        if has_projections {
+            self.apply_projections(&mut transaction, &stream_id, &metadata, appended)
+                .await?;
         }
 
         transaction.commit().await.map_err(crate::db_error)?;

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use futures::future::BoxFuture;
 use futures::{StreamExt, TryStream, TryStreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
@@ -24,6 +25,55 @@ use replay::{Compactable, Event, Metadata};
 pub trait PostgresInlineProjection: InlineProjection<Exec = sqlx::PgConnection> {}
 
 impl<T> PostgresInlineProjection for T where T: InlineProjection<Exec = sqlx::PgConnection> {}
+
+type BoxedPostgresEventHandler<E> = Box<
+    dyn for<'a> FnMut(
+            &'a mut sqlx::PgConnection,
+            &'a [PersistedEvent<E>],
+        ) -> BoxFuture<'a, Result<(), replay::Error>>
+        + Send
+        + Sync,
+>;
+
+struct PostgresEventHandlerProjection<E>
+where
+    E: Event + DeserializeOwned + Send + Sync + 'static,
+{
+    name: String,
+    version: i32,
+    handler: BoxedPostgresEventHandler<E>,
+}
+
+impl<E> InlineProjection for PostgresEventHandlerProjection<E>
+where
+    E: Event + DeserializeOwned + Send + Sync + 'static,
+{
+    type Exec = sqlx::PgConnection;
+    type Event = E;
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn version(&self) -> i32 {
+        self.version
+    }
+
+    fn init(
+        &mut self,
+        _conn: &mut Self::Exec,
+    ) -> impl std::future::Future<Output = Result<(), replay::Error>> + Send {
+        async { Ok(()) }
+    }
+
+    fn handle(
+        &mut self,
+        conn: &mut Self::Exec,
+        events: &[PersistedEvent<Self::Event>],
+    ) -> impl std::future::Future<Output = Result<(), replay::Error>> + Send {
+        async move { (self.handler)(conn, events).await }
+    }
+}
 
 /// A registered inline projection, guarded by a mutex so its `&mut self`
 /// `handle`/`init` methods can be driven through the shared (`&self`) store.
@@ -152,6 +202,34 @@ impl PostgresEventStoreBuilder {
         P: PostgresInlineProjection + 'static,
     {
         self.register(projection)
+    }
+
+    /// Register a Postgres inline projection by providing only the event handler.
+    ///
+    /// This is the low-ceremony path for the common case where the projection's
+    /// table/indexes are created by normal SQL migrations and the runtime work is
+    /// simply "execute some SQL for each batch of events". `init` is a no-op.
+    pub fn register_postgres_event_handler<E, H>(
+        self,
+        name: impl Into<String>,
+        version: i32,
+        handler: H,
+    ) -> Self
+    where
+        E: Event + DeserializeOwned + Send + Sync + 'static,
+        H: for<'a> FnMut(
+                &'a mut sqlx::PgConnection,
+                &'a [PersistedEvent<E>],
+            ) -> BoxFuture<'a, Result<(), replay::Error>>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.register(PostgresEventHandlerProjection {
+            name: name.into(),
+            version,
+            handler: Box::new(handler),
+        })
     }
 
     /// Register an inline projection.

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use futures::{StreamExt, TryStream, TryStreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
@@ -6,20 +8,43 @@ use sqlx::{
     types::chrono::{self, Utc},
     Pool, Postgres, QueryBuilder, Row,
 };
+use tokio::sync::Mutex;
 
 use urn::Urn;
 use uuid::Uuid;
 
+use crate::inline_projection::{ErasedInlineProjection, InlineProjection};
 use crate::{EventStore, PersistedEvent, StreamFilter};
 use replay::{Compactable, Event, Metadata};
 
+/// A registered inline projection, guarded by a mutex so its `&mut self`
+/// `handle`/`init` methods can be driven through the shared (`&self`) store.
+type RegisteredProjection = Mutex<Box<dyn ErasedInlineProjection>>;
+
 pub struct PostgresEventStore {
     pool: Pool<Postgres>,
+    /// Builder-fixed, immutable set of inline projections. The `Vec` itself never
+    /// changes after `build()`; each projection is individually locked while applied.
+    projections: Arc<Vec<RegisteredProjection>>,
 }
 
 impl PostgresEventStore {
     pub fn new(pool: Pool<Postgres>) -> PostgresEventStore {
-        PostgresEventStore { pool }
+        PostgresEventStore {
+            pool,
+            projections: Arc::new(Vec::new()),
+        }
+    }
+
+    /// Begin configuring a store with inline projections.
+    ///
+    /// Projections are registered on the builder and frozen by [`PostgresEventStoreBuilder::build`],
+    /// which runs their first-time `init` and records their version in the `projections` table.
+    pub fn builder(pool: Pool<Postgres>) -> PostgresEventStoreBuilder {
+        PostgresEventStoreBuilder {
+            pool,
+            projections: Vec::new(),
+        }
     }
 
     fn add_filters(query_builder: &mut QueryBuilder<Postgres>, filter: StreamFilter) {
@@ -98,6 +123,69 @@ impl PostgresEventStore {
                 query_builder.push(")");
             }
         }
+    }
+}
+
+/// Builder for a [`PostgresEventStore`] with inline projections.
+///
+/// Register projections with [`register`](Self::register), then call
+/// [`build`](Self::build) to run first-time `init` and freeze the registry.
+pub struct PostgresEventStoreBuilder {
+    pool: Pool<Postgres>,
+    projections: Vec<Box<dyn ErasedInlineProjection>>,
+}
+
+impl PostgresEventStoreBuilder {
+    /// Register an inline projection.
+    pub fn register<P>(mut self, projection: P) -> Self
+    where
+        P: InlineProjection + 'static,
+    {
+        self.projections.push(Box::new(projection));
+        self
+    }
+
+    /// Run first-time setup for the registered projections and freeze the store.
+    ///
+    /// For each projection that is not yet present in the `projections` table, runs its
+    /// `init` and inserts its version row. All setup happens in a single transaction, so a
+    /// failure leaves the registry table untouched.
+    ///
+    /// Version-drift handling (reset + replay) and the stored-newer-than-code guard are
+    /// added by later slices; this build only covers first-time registration.
+    pub async fn build(self) -> Result<PostgresEventStore, replay::Error> {
+        let mut tx = self.pool.begin().await.map_err(crate::db_error)?;
+
+        let mut registered: Vec<RegisteredProjection> = Vec::with_capacity(self.projections.len());
+
+        for mut projection in self.projections {
+            let existing: Option<i32> =
+                sqlx::query_scalar("SELECT version FROM projections WHERE name = $1")
+                    .bind(projection.name())
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(crate::db_error)?;
+
+            if existing.is_none() {
+                projection.init(&mut tx).await?;
+
+                sqlx::query("INSERT INTO projections (name, version) VALUES ($1, $2)")
+                    .bind(projection.name())
+                    .bind(projection.version())
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(crate::db_error)?;
+            }
+
+            registered.push(Mutex::new(projection));
+        }
+
+        tx.commit().await.map_err(crate::db_error)?;
+
+        Ok(PostgresEventStore {
+            pool: self.pool,
+            projections: Arc::new(registered),
+        })
     }
 }
 
@@ -284,6 +372,7 @@ impl Clone for PostgresEventStore {
     fn clone(&self) -> Self {
         Self {
             pool: self.pool.clone(),
+            projections: self.projections.clone(),
         }
     }
 }

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -17,6 +17,14 @@ use crate::inline_projection::{ErasedInlineProjection, InlineProjection};
 use crate::{EventStore, PersistedEvent, StreamFilter};
 use replay::{Compactable, Event, Metadata};
 
+/// Convenience marker trait for inline projections that run on Postgres.
+///
+/// Implement this by implementing [`InlineProjection`] with
+/// `type Exec = sqlx::PgConnection`; the blanket impl below wires it up.
+pub trait PostgresInlineProjection: InlineProjection<Exec = sqlx::PgConnection> {}
+
+impl<T> PostgresInlineProjection for T where T: InlineProjection<Exec = sqlx::PgConnection> {}
+
 /// A registered inline projection, guarded by a mutex so its `&mut self`
 /// `handle`/`init` methods can be driven through the shared (`&self`) store.
 type RegisteredProjection = Mutex<Box<dyn ErasedInlineProjection<Exec = sqlx::PgConnection>>>;
@@ -136,6 +144,16 @@ pub struct PostgresEventStoreBuilder {
 }
 
 impl PostgresEventStoreBuilder {
+    /// Register a new Postgres inline projection.
+    ///
+    /// This helper makes the Postgres-specific intent explicit at call sites.
+    pub fn register_new_postgres_inline_projection<P>(self, projection: P) -> Self
+    where
+        P: PostgresInlineProjection + 'static,
+    {
+        self.register(projection)
+    }
+
     /// Register an inline projection.
     pub fn register<P>(mut self, projection: P) -> Self
     where

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -193,52 +193,20 @@ impl PostgresEventStore {
     /// Apply the just-appended events to every registered inline projection, inside the
     /// store's open transaction.
     ///
-    /// The DB-assigned `version`/`created` for each appended event are read back (by id)
-    /// so projections receive faithful `PersistedEvent`s. Each projection is locked
-    /// individually and routes the batch by deserialize-or-skip; any projection error
-    /// propagates and rolls back the whole append.
+    /// Each projection is locked individually and routes the batch by deserialize-or-skip;
+    /// any projection error propagates and rolls back the whole append.
     async fn apply_projections(
         &self,
         conn: &mut sqlx::PgConnection,
-        stream_id: &Urn,
-        metadata: &Metadata,
-        appended: Vec<(Uuid, String, Value)>,
+        events: &[PersistedEvent<Value>],
     ) -> Result<(), replay::Error> {
-        let mut events: Vec<PersistedEvent<Value>> = Vec::with_capacity(appended.len());
-
-        for (id, event_type, data) in appended {
-            let row = sqlx::query("SELECT version, created FROM events WHERE id = $1")
-                .bind(id)
-                .fetch_optional(&mut *conn)
-                .await
-                .map_err(crate::db_error)?;
-
-            // Absent only when the append did not insert a row (e.g. a concurrency
-            // conflict swallowed by append_event — see follow-up issue). Skip it here.
-            let Some(row) = row else { continue };
-
-            let version: i64 = row.get("version");
-            let created: chrono::DateTime<Utc> = row.get("created");
-
-            events.push(PersistedEvent {
-                id,
-                data,
-                stream_id: stream_id.clone(),
-                r#type: event_type,
-                version,
-                created,
-                metadata: metadata.clone(),
-                aggregate_version: None,
-            });
-        }
-
         if events.is_empty() {
             return Ok(());
         }
 
         for projection in self.projections.iter() {
             let mut projection = projection.lock().await;
-            projection.handle(&mut *conn, &events).await?;
+            projection.handle(&mut *conn, events).await?;
         }
 
         Ok(())
@@ -261,7 +229,7 @@ impl EventStore for PostgresEventStore {
         // inside this same transaction. We only retain what's needed to rebuild the
         // PersistedEvent: the generated id, the JSON payload and the event type.
         let has_projections = !self.projections.is_empty();
-        let mut appended: Vec<(Uuid, String, Value)> = if has_projections {
+        let mut appended: Vec<PersistedEvent<Value>> = if has_projections {
             Vec::with_capacity(domain_events.len())
         } else {
             Vec::new()
@@ -272,28 +240,43 @@ impl EventStore for PostgresEventStore {
             let event = serde_json::to_value(event).map_err(crate::ser_error)?;
             let id = Uuid::new_v4();
 
-            sqlx::query!(
-                "SELECT append_event($1, $2, $3, $4, $5, $6, $7) ",
-                id,
-                event,
-                metadata.to_json(),
-                event_type,
-                stream_id.to_string(),
-                stream_type,
-                expected_version
+            let row = sqlx::query(
+                "SELECT id, version, created FROM append_event($1, $2, $3, $4, $5, $6, $7)",
             )
+            .bind(id)
+            .bind(&event)
+            .bind(metadata.to_json())
+            .bind(&event_type)
+            .bind(stream_id.to_string())
+            .bind(&stream_type)
+            .bind(expected_version)
             .fetch_optional(&mut *transaction)
             .await
             .map_err(crate::db_error)?;
 
             if has_projections {
-                appended.push((id, event_type, event));
+                // No row means optimistic-concurrency mismatch in append_event.
+                let Some(row) = row else { continue };
+
+                let persisted_id: Uuid = row.get("id");
+                let version: i64 = row.get("version");
+                let created: chrono::DateTime<Utc> = row.get("created");
+
+                appended.push(PersistedEvent {
+                    id: persisted_id,
+                    data: event,
+                    stream_id: stream_id.clone(),
+                    r#type: event_type,
+                    version,
+                    created,
+                    metadata: metadata.clone(),
+                    aggregate_version: None,
+                });
             }
         }
 
         if has_projections {
-            self.apply_projections(&mut transaction, &stream_id, &metadata, appended)
-                .await?;
+            self.apply_projections(&mut transaction, &appended).await?;
         }
 
         transaction.commit().await.map_err(crate::db_error)?;

--- a/persistence/src/inline_projection.rs
+++ b/persistence/src/inline_projection.rs
@@ -3,17 +3,15 @@ use std::future::Future;
 use futures::future::BoxFuture;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use sqlx::PgConnection;
 
 use crate::PersistedEvent;
 use replay::Event;
 
 /// An inline projection: a persisted read model whose write is applied inside the
-/// same transaction that appends the events, against the same Postgres store.
+/// same transaction that appends the events, against the same store instance.
 ///
-/// Inline projections are intentionally **not** store-agnostic — the write handle
-/// is a concrete Postgres connection (`&mut PgConnection`, obtained from the store's
-/// own transaction). The store drives the projection while it holds that transaction,
+/// The write handle type is supplied by the store as the associated `Exec` type.
+/// The store drives the projection while it holds that transaction/connection,
 /// so the read-model write commits atomically with the events.
 ///
 /// Implementors declare the events they consume via the associated [`Event`](Self::Event)
@@ -21,6 +19,9 @@ use replay::Event;
 /// its `Deserialize` impl tries each underlying event type in turn, which lets the store
 /// route appended events by deserialize-or-skip.
 pub trait InlineProjection: Send + Sync {
+    /// Concrete write-handle type supplied by the store.
+    type Exec: Send;
+
     /// The event type this projection consumes. Typically a `query_events!`-merged enum.
     type Event: Event + DeserializeOwned;
 
@@ -39,7 +40,7 @@ pub trait InlineProjection: Send + Sync {
     /// connection so the setup participates in the registration transaction.
     fn init(
         &mut self,
-        conn: &mut PgConnection,
+        conn: &mut Self::Exec,
     ) -> impl Future<Output = Result<(), replay::Error>> + Send;
 
     /// Apply a batch of newly-appended events to the read model.
@@ -50,26 +51,26 @@ pub trait InlineProjection: Send + Sync {
     /// transaction, so they commit atomically with the appended events.
     fn handle(
         &mut self,
-        conn: &mut PgConnection,
+        conn: &mut Self::Exec,
         events: &[PersistedEvent<Self::Event>],
     ) -> impl Future<Output = Result<(), replay::Error>> + Send;
 }
 
 /// Object-safe, type-erased view of an [`InlineProjection`] used by the store's registry.
 ///
-/// The store holds projections as `Box<dyn ErasedInlineProjection>` so that projections
+/// The store holds projections as `Box<dyn ErasedInlineProjection<Exec = ...>>` so that projections
 /// over different event types can live in a single registry. The erased `handle` receives
 /// raw JSON-backed events and bridges them to the projection's typed event via
 /// deserialize-or-skip.
 pub(crate) trait ErasedInlineProjection: Send + Sync {
+    type Exec;
+
     fn name(&self) -> &str;
 
     fn version(&self) -> i32;
 
-    fn init<'a>(
-        &'a mut self,
-        conn: &'a mut PgConnection,
-    ) -> BoxFuture<'a, Result<(), replay::Error>>;
+    fn init<'a>(&'a mut self, conn: &'a mut Self::Exec)
+        -> BoxFuture<'a, Result<(), replay::Error>>;
 
     /// Route raw appended events to the underlying typed projection.
     ///
@@ -78,7 +79,7 @@ pub(crate) trait ErasedInlineProjection: Send + Sync {
     /// called.
     fn handle<'a>(
         &'a mut self,
-        conn: &'a mut PgConnection,
+        conn: &'a mut Self::Exec,
         events: &'a [PersistedEvent<Value>],
     ) -> BoxFuture<'a, Result<(), replay::Error>>;
 }
@@ -87,6 +88,8 @@ impl<T> ErasedInlineProjection for T
 where
     T: InlineProjection,
 {
+    type Exec = T::Exec;
+
     fn name(&self) -> &str {
         InlineProjection::name(self)
     }
@@ -97,14 +100,14 @@ where
 
     fn init<'a>(
         &'a mut self,
-        conn: &'a mut PgConnection,
+        conn: &'a mut Self::Exec,
     ) -> BoxFuture<'a, Result<(), replay::Error>> {
         Box::pin(InlineProjection::init(self, conn))
     }
 
     fn handle<'a>(
         &'a mut self,
-        conn: &'a mut PgConnection,
+        conn: &'a mut Self::Exec,
         events: &'a [PersistedEvent<Value>],
     ) -> BoxFuture<'a, Result<(), replay::Error>> {
         Box::pin(async move {

--- a/persistence/src/inline_projection.rs
+++ b/persistence/src/inline_projection.rs
@@ -1,0 +1,128 @@
+use std::future::Future;
+
+use futures::future::BoxFuture;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use sqlx::PgConnection;
+
+use crate::PersistedEvent;
+use replay::Event;
+
+/// An inline projection: a persisted read model whose write is applied inside the
+/// same transaction that appends the events, against the same Postgres store.
+///
+/// Inline projections are intentionally **not** store-agnostic — the write handle
+/// is a concrete Postgres connection (`&mut PgConnection`, obtained from the store's
+/// own transaction). The store drives the projection while it holds that transaction,
+/// so the read-model write commits atomically with the events.
+///
+/// Implementors declare the events they consume via the associated [`Event`](Self::Event)
+/// type. The merged enum produced by the `query_events!` macro is the intended choice:
+/// its `Deserialize` impl tries each underlying event type in turn, which lets the store
+/// route appended events by deserialize-or-skip.
+pub trait InlineProjection: Send + Sync {
+    /// The event type this projection consumes. Typically a `query_events!`-merged enum.
+    type Event: Event + DeserializeOwned;
+
+    /// Stable identity of this projection in the `projections` registry table.
+    ///
+    /// This is the registry key and MUST be stable across refactors — do not derive it
+    /// from the Rust type name.
+    fn name(&self) -> &str;
+
+    /// Author-managed code version of this projection's logic/schema.
+    fn version(&self) -> i32;
+
+    /// Create the projection's view table and any supporting schema.
+    ///
+    /// Called once when the projection is first registered. Runs against the store's
+    /// connection so the setup participates in the registration transaction.
+    fn init(
+        &mut self,
+        conn: &mut PgConnection,
+    ) -> impl Future<Output = Result<(), replay::Error>> + Send;
+
+    /// Apply a batch of newly-appended events to the read model.
+    ///
+    /// The batch contains only the events that belong to this projection (events that
+    /// failed to deserialize into [`Event`](Self::Event) are filtered out before this is
+    /// called) and is never empty. Writes go through `conn`, which is the store's active
+    /// transaction, so they commit atomically with the appended events.
+    fn handle(
+        &mut self,
+        conn: &mut PgConnection,
+        events: &[PersistedEvent<Self::Event>],
+    ) -> impl Future<Output = Result<(), replay::Error>> + Send;
+}
+
+/// Object-safe, type-erased view of an [`InlineProjection`] used by the store's registry.
+///
+/// The store holds projections as `Box<dyn ErasedInlineProjection>` so that projections
+/// over different event types can live in a single registry. The erased `handle` receives
+/// raw JSON-backed events and bridges them to the projection's typed event via
+/// deserialize-or-skip.
+pub(crate) trait ErasedInlineProjection: Send + Sync {
+    fn name(&self) -> &str;
+
+    fn version(&self) -> i32;
+
+    fn init<'a>(
+        &'a mut self,
+        conn: &'a mut PgConnection,
+    ) -> BoxFuture<'a, Result<(), replay::Error>>;
+
+    /// Route raw appended events to the underlying typed projection.
+    ///
+    /// Each event's JSON `data` is deserialized into the projection's event type; events
+    /// that do not match are skipped. If no events match, the underlying `handle` is not
+    /// called.
+    fn handle<'a>(
+        &'a mut self,
+        conn: &'a mut PgConnection,
+        events: &'a [PersistedEvent<Value>],
+    ) -> BoxFuture<'a, Result<(), replay::Error>>;
+}
+
+impl<T> ErasedInlineProjection for T
+where
+    T: InlineProjection,
+{
+    fn name(&self) -> &str {
+        InlineProjection::name(self)
+    }
+
+    fn version(&self) -> i32 {
+        InlineProjection::version(self)
+    }
+
+    fn init<'a>(
+        &'a mut self,
+        conn: &'a mut PgConnection,
+    ) -> BoxFuture<'a, Result<(), replay::Error>> {
+        Box::pin(InlineProjection::init(self, conn))
+    }
+
+    fn handle<'a>(
+        &'a mut self,
+        conn: &'a mut PgConnection,
+        events: &'a [PersistedEvent<Value>],
+    ) -> BoxFuture<'a, Result<(), replay::Error>> {
+        Box::pin(async move {
+            // Deserialize-or-skip: keep only events that belong to this projection.
+            let typed: Vec<PersistedEvent<T::Event>> = events
+                .iter()
+                .filter_map(|event| {
+                    serde_json::from_value::<T::Event>(event.data.clone())
+                        .ok()
+                        .map(|data| event.clone().with_data(data))
+                })
+                .collect();
+
+            if typed.is_empty() {
+                return Ok(());
+            }
+
+            InlineProjection::handle(self, conn, &typed).await
+        })
+    }
+}

--- a/persistence/src/lib.rs
+++ b/persistence/src/lib.rs
@@ -3,6 +3,7 @@ mod cqrs;
 mod error;
 mod filters;
 mod infrastructure;
+mod inline_projection;
 mod persisted_event;
 mod query;
 mod store;
@@ -12,6 +13,7 @@ pub use cqrs::Cqrs;
 pub use error::{concurrency_error, db_error, deser_error, ser_error};
 pub use filters::StreamFilter;
 pub use infrastructure::{InMemoryEventStore, PostgresEventStore};
+pub use inline_projection::InlineProjection;
 pub use persisted_event::PersistedEvent;
 pub use query::Query;
 pub use store::EventStore;
@@ -35,7 +37,7 @@ pub mod prelude {
 
     // Persistence types from this crate
     pub use super::{
-        AggregateVersion, Cqrs, EventStore, InMemoryEventStore, PersistedEvent, PostgresEventStore,
-        Query, StreamFilter,
+        AggregateVersion, Cqrs, EventStore, InMemoryEventStore, InlineProjection, PersistedEvent,
+        PostgresEventStore, Query, StreamFilter,
     };
 }

--- a/persistence/src/lib.rs
+++ b/persistence/src/lib.rs
@@ -12,7 +12,7 @@ pub use aggregate_version::AggregateVersion;
 pub use cqrs::Cqrs;
 pub use error::{concurrency_error, db_error, deser_error, ser_error};
 pub use filters::StreamFilter;
-pub use infrastructure::{InMemoryEventStore, PostgresEventStore};
+pub use infrastructure::{InMemoryEventStore, PostgresEventStore, PostgresInlineProjection};
 pub use inline_projection::InlineProjection;
 pub use persisted_event::PersistedEvent;
 pub use query::Query;
@@ -38,6 +38,6 @@ pub mod prelude {
     // Persistence types from this crate
     pub use super::{
         AggregateVersion, Cqrs, EventStore, InMemoryEventStore, InlineProjection, PersistedEvent,
-        PostgresEventStore, Query, StreamFilter,
+        PostgresEventStore, PostgresInlineProjection, Query, StreamFilter,
     };
 }

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -512,6 +512,7 @@ async fn bank_account_compaction_postgres_test() {
 struct BalanceProjection;
 
 impl replay_persistence::InlineProjection for BalanceProjection {
+    type Exec = sqlx::PgConnection;
     type Event = BankAccountEvent;
 
     fn name(&self) -> &str {

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -503,6 +503,144 @@ async fn bank_account_compaction_postgres_test() {
     );
 }
 
+// ── Inline projection (issue #58) ─────────────────────────────────────────────
+
+/// An inline projection that maintains a per-account balance in its own view table.
+///
+/// Its write is applied inside the same transaction that appends the events, so the
+/// view can never diverge from the committed event stream.
+struct BalanceProjection;
+
+impl replay_persistence::InlineProjection for BalanceProjection {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "account_balance_view"
+    }
+
+    fn version(&self) -> i32 {
+        1
+    }
+
+    async fn init(&mut self, conn: &mut sqlx::PgConnection) -> Result<(), replay::Error> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS account_balances (
+                stream_id text PRIMARY KEY,
+                balance   double precision NOT NULL
+            )",
+        )
+        .execute(conn)
+        .await
+        .map_err(replay_persistence::db_error)?;
+        Ok(())
+    }
+
+    async fn handle(
+        &mut self,
+        conn: &mut sqlx::PgConnection,
+        events: &[PersistedEvent<Self::Event>],
+    ) -> Result<(), replay::Error> {
+        for event in events {
+            let delta = match &event.data {
+                BankAccountEvent::Deposited { amount, .. } => *amount,
+                BankAccountEvent::Withdrawn { amount, .. } => -*amount,
+                BankAccountEvent::MonthlyClosed { .. } => continue,
+            };
+
+            sqlx::query(
+                "INSERT INTO account_balances (stream_id, balance)
+                 VALUES ($1, $2)
+                 ON CONFLICT (stream_id)
+                 DO UPDATE SET balance = account_balances.balance + EXCLUDED.balance",
+            )
+            .bind(event.stream_id.to_string())
+            .bind(delta)
+            .execute(&mut *conn)
+            .await
+            .map_err(replay_persistence::db_error)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// End-to-end test for the inline-projection walking skeleton.
+///
+/// Registers a `BalanceProjection` via the builder, executes commands through `Cqrs`,
+/// and asserts the projection's view table reflects the events and that its version is
+/// recorded in the `projections` registry.
+#[tokio::test]
+async fn bank_account_inline_projection_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    // Build the store with the inline projection registered. build() runs init and
+    // records the projection version.
+    let store = replay_persistence::PostgresEventStore::builder(pg_pool.clone())
+        .register(BalanceProjection)
+        .build()
+        .await
+        .expect("Failed to build store with inline projection");
+
+    let cqrs = replay_persistence::Cqrs::new(store);
+
+    let stream_id = BankAccountUrn::new("inline-proj-1").unwrap();
+    let services = &();
+
+    for command in [
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        BankAccountCommand::Withdraw {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 2).unwrap(),
+            amount: 40.0,
+        },
+    ] {
+        cqrs.execute::<BankAccount>(
+            &stream_id,
+            replay::Metadata::default(),
+            command,
+            services,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    // The inline projection's view table must reflect the events (100 - 40 = 60).
+    let stream_id_str = Into::<Urn>::into(stream_id.clone()).to_string();
+    let balance: f64 =
+        sqlx::query_scalar("SELECT balance FROM account_balances WHERE stream_id = $1")
+            .bind(&stream_id_str)
+            .fetch_one(&pg_pool)
+            .await
+            .expect("balance view row must exist");
+
+    assert_eq!(balance, 60.0);
+
+    // The projection version must be recorded in the registry.
+    let version: i32 = sqlx::query_scalar("SELECT version FROM projections WHERE name = $1")
+        .bind("account_balance_view")
+        .fetch_one(&pg_pool)
+        .await
+        .expect("projection registry row must exist");
+
+    assert_eq!(version, 1);
+}
+
 // ── Scoped-URN types used by the tests below ─────────────────────────────────
 
 /// A branch that owns one or more bank accounts.

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -505,66 +505,6 @@ async fn bank_account_compaction_postgres_test() {
 
 // ── Inline projection (issue #58) ─────────────────────────────────────────────
 
-/// An inline projection that maintains a per-account balance in its own view table.
-///
-/// Its write is applied inside the same transaction that appends the events, so the
-/// view can never diverge from the committed event stream.
-struct BalanceProjection;
-
-impl replay_persistence::InlineProjection for BalanceProjection {
-    type Exec = sqlx::PgConnection;
-    type Event = BankAccountEvent;
-
-    fn name(&self) -> &str {
-        "account_balance_view"
-    }
-
-    fn version(&self) -> i32 {
-        1
-    }
-
-    async fn init(&mut self, conn: &mut sqlx::PgConnection) -> Result<(), replay::Error> {
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS account_balances (
-                stream_id text PRIMARY KEY,
-                balance   double precision NOT NULL
-            )",
-        )
-        .execute(conn)
-        .await
-        .map_err(replay_persistence::db_error)?;
-        Ok(())
-    }
-
-    async fn handle(
-        &mut self,
-        conn: &mut sqlx::PgConnection,
-        events: &[PersistedEvent<Self::Event>],
-    ) -> Result<(), replay::Error> {
-        for event in events {
-            let delta = match &event.data {
-                BankAccountEvent::Deposited { amount, .. } => *amount,
-                BankAccountEvent::Withdrawn { amount, .. } => -*amount,
-                BankAccountEvent::MonthlyClosed { .. } => continue,
-            };
-
-            sqlx::query(
-                "INSERT INTO account_balances (stream_id, balance)
-                 VALUES ($1, $2)
-                 ON CONFLICT (stream_id)
-                 DO UPDATE SET balance = account_balances.balance + EXCLUDED.balance",
-            )
-            .bind(event.stream_id.to_string())
-            .bind(delta)
-            .execute(&mut *conn)
-            .await
-            .map_err(replay_persistence::db_error)?;
-        }
-
-        Ok(())
-    }
-}
-
 /// End-to-end test for the inline-projection walking skeleton.
 ///
 /// Registers a `BalanceProjection` via the builder, executes commands through `Cqrs`,
@@ -587,10 +527,50 @@ async fn bank_account_inline_projection_postgres_test() {
         .await
         .expect("Failed to run migrations");
 
-    // Build the store with the inline projection registered. build() runs init and
-    // records the projection version.
+    // In normal usage, the projection table is created by SQL migrations rather than
+    // by the projection runtime itself.
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS account_balances (
+            stream_id text PRIMARY KEY,
+            balance   double precision NOT NULL
+        )",
+    )
+    .execute(&pg_pool)
+    .await
+    .expect("Failed to create account_balances test table");
+
+    // Build the store with a low-ceremony Postgres event handler. The schema already
+    // exists, so the helper only needs the SQL to run for each event batch.
     let store = replay_persistence::PostgresEventStore::builder(pg_pool.clone())
-        .register(BalanceProjection)
+        .register_postgres_event_handler::<BankAccountEvent, _>(
+            "account_balance_view",
+            1,
+            |conn, events| {
+                Box::pin(async move {
+                    for event in events {
+                        let delta = match &event.data {
+                            BankAccountEvent::Deposited { amount, .. } => *amount,
+                            BankAccountEvent::Withdrawn { amount, .. } => -*amount,
+                            BankAccountEvent::MonthlyClosed { .. } => continue,
+                        };
+
+                        sqlx::query(
+                            "INSERT INTO account_balances (stream_id, balance)
+                             VALUES ($1, $2)
+                             ON CONFLICT (stream_id)
+                             DO UPDATE SET balance = account_balances.balance + EXCLUDED.balance",
+                        )
+                        .bind(event.stream_id.to_string())
+                        .bind(delta)
+                        .execute(&mut *conn)
+                        .await
+                        .map_err(replay_persistence::db_error)?;
+                    }
+
+                    Ok(())
+                })
+            },
+        )
         .build()
         .await
         .expect("Failed to build store with inline projection");

--- a/persistence/tests/migrations/0003_projections.sql
+++ b/persistence/tests/migrations/0003_projections.sql
@@ -1,0 +1,14 @@
+-- Registry of inline projections and their applied code version.
+--
+-- One row per inline projection, keyed by the projection's stable `name()`
+-- (NOT the Rust type name). `version` is the author-managed code version that
+-- was last applied to this projection's view. `updated_at` records when the
+-- row was last written.
+--
+-- This migration only creates the registry table. Version-drift handling
+-- (reset + replay) and the version guard are added by later slices.
+CREATE TABLE IF NOT EXISTS projections (
+    name        TEXT                        NOT NULL    PRIMARY KEY,
+    version     INTEGER                     NOT NULL,
+    updated_at  TIMESTAMP WITH TIME ZONE    NOT NULL    DEFAULT (now())
+);

--- a/persistence/tests/migrations/0004_append_event_returns_persisted_row.sql
+++ b/persistence/tests/migrations/0004_append_event_returns_persisted_row.sql
@@ -1,0 +1,67 @@
+-- Evolve append_event to return persisted event metadata used by inline projections.
+--
+-- Previous signature:
+--   append_event(...) RETURNS boolean
+-- New signature:
+--   append_event(...) RETURNS TABLE(id uuid, version bigint, created timestamptz)
+--
+-- Behavior:
+-- - On successful append: returns exactly one row with persisted id/version/created.
+-- - On optimistic-concurrency mismatch: returns zero rows.
+
+CREATE OR REPLACE FUNCTION append_event(
+    p_id uuid,
+    p_data jsonb,
+    p_metadata jsonb,
+    p_type text,
+    p_stream_id text,
+    p_stream_type text,
+    p_expected_stream_version bigint default null
+) RETURNS TABLE(id uuid, version bigint, created timestamp with time zone)
+  LANGUAGE plpgsql
+  AS $$
+  DECLARE
+    stream_version bigint;
+    persisted_created timestamp with time zone;
+  BEGIN
+    -- get stream version
+    SELECT
+      s.version INTO stream_version
+    FROM streams as s
+    WHERE
+      s.id = p_stream_id FOR UPDATE;
+
+    -- if stream doesn't exist - create new one with version 0
+    IF stream_version IS NULL THEN
+      stream_version := 0;
+
+      INSERT INTO streams
+      (id, type, version)
+      VALUES
+      (p_stream_id, p_stream_type, stream_version);
+    END IF;
+
+    -- check optimistic concurrency
+    IF p_expected_stream_version IS NOT NULL AND stream_version != p_expected_stream_version THEN
+        RETURN;
+    END IF;
+
+    -- increment event_version
+    stream_version := stream_version + 1;
+
+    -- append event
+    INSERT INTO events
+        (id, data, metadata, stream_id, type, version)
+    VALUES
+        (p_id, p_data, p_metadata, p_stream_id, p_type, stream_version)
+    RETURNING events.created INTO persisted_created;
+
+    -- update stream version
+    UPDATE streams as s
+        SET version = stream_version
+    WHERE
+        s.id = p_stream_id;
+
+    RETURN QUERY SELECT p_id, stream_version, persisted_created;
+  END;
+$$;


### PR DESCRIPTION
Implements the inline-projections walking skeleton (#58): a persisted read model whose write is applied inside the same transaction that appends the events, on Postgres.

## What's included

- **`InlineProjection` trait** (`persistence/src/inline_projection.rs`): `type Event`, `name()`, `version()`, async `init`, async `handle(&mut self, conn, events)`. The write handle is a concrete `&mut PgConnection` (Postgres-specific by design, ADR-0001). An internal `ErasedInlineProjection` wrapper routes raw appended events to the typed projection by **deserialize-or-skip** (ADR-0002).
- **Builder + registry** on `PostgresEventStore`: `PostgresEventStore::builder(pool).register(..).build().await?`. `build()` runs each projection's first-time `init` and records its version in a new `projections` table, in one transaction, then freezes an immutable registry. `new(pool)` keeps an empty registry.
- **Atomic apply inside `store_events`**: after appending events, the store reads back their DB-assigned `version`/`created` and drives each registered projection's `handle` against the same transaction, so read-model writes commit atomically with the events. No-op when no projections are registered. `EventStore` trait signature and `Cqrs::execute` are unchanged.
- **Migration `0003_projections.sql`**: `projections(name PK, version, updated_at)`.
- **Design docs**: projections glossary (`CONTEXT.md`) and ADRs 0001/0002.
- **End-to-end test**: `bank_account_inline_projection_postgres_test` registers a balance projection, runs commands through `Cqrs`, and asserts the view table and registry version.

## Scope / follow-ups

- Version-drift reset+replay (#60), version guard + logging (#62), atomic rollback test (#59), and best-effort in-memory projections (#61) are separate slices.
- `append_event` still returns `boolean` and swallows concurrency conflicts; this PR reads back `version`/`created` by id to avoid changing that contract. Captured as #63 (return assigned version/created and surface conflicts).

## Testing

- `cargo build --workspace`, `cargo clippy -p es-replay-persistence --all-targets`, and `cargo test -p es-replay-persistence --lib` all pass.
- The new Postgres integration test compiles; it requires Docker (testcontainers) to run and is expected to run in CI (no Docker available in the authoring environment).

Closes #58
