### PR TITLE
chore(repo): add pre-commit hook running fmt, clippy, and tests

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook: run lint and tests before allowing a commit.
+#
+# Install with:
+#   git config core.hooksPath .githooks
+# or:
+#   make install-hooks
+#
+# Skip on a one-off commit with:
+#   git commit --no-verify
+#
+# Skip the (Docker-dependent) tests with:
+#   SKIP_TESTS=1 git commit
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+echo "pre-commit: cargo fmt --check"
+cargo fmt --all -- --check
+
+echo "pre-commit: cargo clippy"
+cargo clippy --workspace --all-targets -- -D warnings
+
+if [[ "${SKIP_TESTS:-0}" == "1" ]]; then
+  echo "pre-commit: SKIP_TESTS=1 set, skipping tests"
+else
+  echo "pre-commit: cargo test"
+  cargo test --workspace
+fi
+
+echo "pre-commit: all checks passed"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,17 @@ pgadmin:
 fix:
 	cargo clippy --fix
 
+.PHONY: install-hooks
+install-hooks:
+	git config core.hooksPath .githooks
+	chmod +x .githooks/*
+	@echo "Git hooks installed (core.hooksPath -> .githooks)."
+
+.PHONY: uninstall-hooks
+uninstall-hooks:
+	git config --unset core.hooksPath
+	@echo "Git hooks uninstalled."
+
 .PHONY: wasm-test
 wasm-test:
 	wasm-pack test --headless --chrome macros-tests


### PR DESCRIPTION
Adds a small, version-controlled git pre-commit hook so lint and tests run before each commit.

## What
- New `.githooks/pre-commit` running:
  - `cargo fmt --all -- --check`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo test --workspace`
- Wired via `core.hooksPath` (not `.git/hooks`), so it's committed to the repo and shared.
- New Make targets: `make install-hooks` / `make uninstall-hooks`.

## Usage
```sh
make install-hooks        # one-time: git config core.hooksPath .githooks
```
Escape hatches:
- `SKIP_TESTS=1 git commit` — skip the Docker-dependent test step (fmt + clippy still run).
- `git commit --no-verify` — bypass the hook entirely.

## Notes
- Tests use testcontainers and require Docker; `SKIP_TESTS=1` is provided for environments without it.
- No production code changes.