### PR TITLE
fix(persistence): surface append_event concurrency conflict as error

### DIFF
--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -350,10 +350,26 @@ impl EventStore for PostgresEventStore {
             .await
             .map_err(crate::db_error)?;
 
-            if has_projections {
-                // No row means optimistic-concurrency mismatch in append_event.
-                let Some(row) = row else { continue };
+            // No row means optimistic-concurrency mismatch in append_event. Surface it as a
+            // concurrency_error (parity with the in-memory store) and let the transaction
+            // roll back so no partial append commits.
+            let Some(row) = row else {
+                let actual_version: i64 =
+                    sqlx::query_scalar("SELECT version FROM streams WHERE id = $1")
+                        .bind(stream_id.to_string())
+                        .fetch_optional(&mut *transaction)
+                        .await
+                        .map_err(crate::db_error)?
+                        .unwrap_or(0);
 
+                return Err(crate::concurrency_error(
+                    stream_id.clone(),
+                    expected_version.unwrap_or(actual_version),
+                    actual_version,
+                ));
+            };
+
+            if has_projections {
                 let persisted_id: Uuid = row.get("id");
                 let version: i64 = row.get("version");
                 let created: chrono::DateTime<Utc> = row.get("created");

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -325,6 +325,71 @@ async fn bank_account_postgres_test() {
     assert_eq!(statement.total_transactions, 2);
 }
 
+/// A stale `expected_version` must surface as a `concurrency_error` (parity with the
+/// in-memory store), and the conflicting append must not persist.
+#[tokio::test]
+async fn bank_account_store_events_concurrency_conflict_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+
+    let stream_id = BankAccountUrn::new("concurrency-1").unwrap();
+    let stream_id_str = Into::<Urn>::into(stream_id.clone()).to_string();
+
+    // First append against a fresh stream (version 0) succeeds and bumps it to version 1.
+    store
+        .store_events::<BankAccount>(
+            &stream_id,
+            "bank-account".to_string(),
+            replay::Metadata::default(),
+            &[BankAccountEvent::Deposited {
+                operation_date: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+                amount: 100.0,
+            }],
+            Some(0),
+        )
+        .await
+        .expect("first append must succeed");
+
+    // Second append still expects version 0, but the stream is now at version 1.
+    let result = store
+        .store_events::<BankAccount>(
+            &stream_id,
+            "bank-account".to_string(),
+            replay::Metadata::default(),
+            &[BankAccountEvent::Deposited {
+                operation_date: chrono::NaiveDate::from_ymd_opt(2025, 1, 2).unwrap(),
+                amount: 50.0,
+            }],
+            Some(0),
+        )
+        .await;
+
+    assert_err!(result, "Stream version mismatch");
+
+    // The conflicting append must not have persisted: only the first event remains.
+    let event_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE stream_id = $1")
+        .bind(&stream_id_str)
+        .fetch_one(&pg_pool)
+        .await
+        .expect("counting events must succeed");
+
+    assert_eq!(event_count, 1);
+}
+
 async fn connect_to_postgres(host: String, port: u16) -> PgPool {
     // connect to Postgres
     PgPoolOptions::new()


### PR DESCRIPTION
Closes #63

`PostgresEventStore::store_events` called `append_event` but ignored a no-row result, so an optimistic-concurrency conflict was silently swallowed: the transaction still committed and returned `Ok(())`. The in-memory store, by contrast, raises `concurrency_error` on a version mismatch.

## What
- When `append_event` returns no row (version conflict), `store_events` now reads the current stream version and raises `concurrency_error(stream_id, expected, actual)`, then lets the transaction roll back so no partial append commits.
- Restores parity with the in-memory store.

## Test
- New `bank_account_store_events_concurrency_conflict_postgres_test`: appends against a fresh stream with `expected_version = Some(0)`, then appends again with a stale `Some(0)`; asserts the second call fails with `Stream version mismatch` and that only the first event persisted.
- Full persistence integration suite passes (12 tests).

## Notes
- The DB-assigned `version`/`created` return shape (other half of #63) already landed via migration `0004` during #58; this PR closes the remaining swallowed-conflict gap.
- No schema change.