### PR TITLE
fix(persistence): use async fn for projection handler methods (clippy)

### DIFF
--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -59,19 +59,16 @@ where
         self.version
     }
 
-    fn init(
-        &mut self,
-        _conn: &mut Self::Exec,
-    ) -> impl std::future::Future<Output = Result<(), replay::Error>> + Send {
-        async { Ok(()) }
+    async fn init(&mut self, _conn: &mut Self::Exec) -> Result<(), replay::Error> {
+        Ok(())
     }
 
-    fn handle(
+    async fn handle(
         &mut self,
         conn: &mut Self::Exec,
         events: &[PersistedEvent<Self::Event>],
-    ) -> impl std::future::Future<Output = Result<(), replay::Error>> + Send {
-        async move { (self.handler)(conn, events).await }
+    ) -> Result<(), replay::Error> {
+        (self.handler)(conn, events).await
     }
 }
 


### PR DESCRIPTION
Fixes two `clippy::manual_async_fn` warnings on `main` that break the new pre-commit hook (#66 runs `clippy --workspace -- -D warnings`).

## What
- Convert `PostgresEventHandlerProjection::{init,handle}` from `-> impl Future + Send` blocks to `async fn`.
- The `async fn` form captures all input lifetimes automatically, so the borrow that previously forced the explicit `async move` block is no longer a problem (no E0700).

## Why
These warnings were pre-existing on main (from the #58 closure helper). With the pre-commit hook now in place, every commit failed clippy until bypassed with `--no-verify`. This restores a clean `clippy -D warnings` so the hook passes.

## Validation
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Full pre-commit hook (fmt + clippy + `cargo test --workspace`) passes locally.

No behavior change.