### PR TITLE
feat(persistence): inline projection version-drift reset and replay (#60)

### DIFF
--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -238,36 +238,75 @@ impl PostgresEventStoreBuilder {
         self
     }
 
-    /// Run first-time setup for the registered projections and freeze the store.
+    /// Run setup for the registered projections and freeze the store.
     ///
-    /// For each projection that is not yet present in the `projections` table, runs its
-    /// `init` and inserts its version row. All setup happens in a single transaction, so a
-    /// failure leaves the registry table untouched.
+    /// For each projection:
+    /// - **First registration** (no stored version): run `init` and record the version.
+    /// - **Version drift** (stored version older than the code version): `reset` the view,
+    ///   replay matching history through `handle`, then update the stored version **last**,
+    ///   all in the same transaction so a crash mid-rebuild never marks a half-built view
+    ///   as current.
     ///
-    /// Version-drift handling (reset + replay) and the stored-newer-than-code guard are
-    /// added by later slices; this build only covers first-time registration.
+    /// The stored-equals-code no-op fast path and the stored-newer-than-code guard are
+    /// added by a later slice; here those cases simply register without changes.
     pub async fn build(self) -> Result<PostgresEventStore, replay::Error> {
         let mut tx = self.pool.begin().await.map_err(crate::db_error)?;
 
         let mut registered: Vec<RegisteredProjection> = Vec::with_capacity(self.projections.len());
 
         for mut projection in self.projections {
-            let existing: Option<i32> =
+            let stored: Option<i32> =
                 sqlx::query_scalar("SELECT version FROM projections WHERE name = $1")
                     .bind(projection.name())
                     .fetch_optional(&mut *tx)
                     .await
                     .map_err(crate::db_error)?;
 
-            if existing.is_none() {
-                projection.init(&mut tx).await?;
+            let code = projection.version();
 
-                sqlx::query("INSERT INTO projections (name, version) VALUES ($1, $2)")
-                    .bind(projection.name())
-                    .bind(projection.version())
-                    .execute(&mut *tx)
-                    .await
-                    .map_err(crate::db_error)?;
+            match stored {
+                // First-time registration: create the view and record the version.
+                None => {
+                    projection.init(&mut tx).await?;
+
+                    sqlx::query("INSERT INTO projections (name, version) VALUES ($1, $2)")
+                        .bind(projection.name())
+                        .bind(code)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(crate::db_error)?;
+                }
+                // Version drift: the code is newer than the stored view. Reset and rebuild
+                // from history, then record the new version LAST so a crash mid-rebuild
+                // never marks a half-built view as current.
+                Some(stored) if stored < code => {
+                    tracing::info!(
+                        projection = projection.name(),
+                        stored,
+                        code,
+                        "inline projection version drift: resetting and replaying history"
+                    );
+
+                    projection.reset(&mut tx).await?;
+
+                    // Replay matching history through the projection. The projection's
+                    // stream_filter narrows which events are scanned. Loaded in one batch
+                    // for now; large histories can be chunked later without changing the
+                    // batch-handling semantics seen by `handle`.
+                    let events =
+                        Self::load_events_for_replay(&mut tx, projection.stream_filter()).await?;
+                    projection.handle(&mut tx, &events).await?;
+
+                    sqlx::query("UPDATE projections SET version = $2 WHERE name = $1")
+                        .bind(projection.name())
+                        .bind(code)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(crate::db_error)?;
+                }
+                // stored == code (no-op fast path) and stored > code (guard) are handled by
+                // a later slice; registering without changes preserves existing behavior.
+                Some(_) => {}
             }
 
             registered.push(Mutex::new(projection));
@@ -279,6 +318,32 @@ impl PostgresEventStoreBuilder {
             pool: self.pool,
             projections: Arc::new(registered),
         })
+    }
+
+    /// Load the events matching `filter` for a projection rebuild, in append order.
+    ///
+    /// Returns JSON-backed [`PersistedEvent`]s; the erased projection routes them to its
+    /// typed `handle` by deserialize-or-skip.
+    async fn load_events_for_replay(
+        tx: &mut sqlx::PgConnection,
+        filter: StreamFilter,
+    ) -> Result<Vec<PersistedEvent<Value>>, replay::Error> {
+        let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(
+            "SELECT id, data, metadata, stream_id, type, version, created, aggregate_version \
+             FROM events WHERE ",
+        );
+        PostgresEventStore::add_filters(&mut query_builder, filter);
+        query_builder.push(" ORDER BY created, version ASC");
+
+        let rows = query_builder
+            .build()
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(crate::db_error)?;
+
+        rows.into_iter()
+            .map(PersistedEvent::<Value>::try_from)
+            .collect()
     }
 }
 

--- a/persistence/src/inline_projection.rs
+++ b/persistence/src/inline_projection.rs
@@ -4,7 +4,7 @@ use futures::future::BoxFuture;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
-use crate::PersistedEvent;
+use crate::{PersistedEvent, StreamFilter};
 use replay::Event;
 
 /// An inline projection: a persisted read model whose write is applied inside the
@@ -34,6 +34,14 @@ pub trait InlineProjection: Send + Sync {
     /// Author-managed code version of this projection's logic/schema.
     fn version(&self) -> i32;
 
+    /// Events to replay when this projection is rebuilt after a version bump.
+    ///
+    /// Returned filter narrows which streams/events the store scans during a drift
+    /// rebuild, so unrelated history is not read. Defaults to [`StreamFilter::All`].
+    fn stream_filter(&self) -> StreamFilter {
+        StreamFilter::All
+    }
+
     /// Create the projection's view table and any supporting schema.
     ///
     /// Called once when the projection is first registered. Runs against the store's
@@ -42,6 +50,20 @@ pub trait InlineProjection: Send + Sync {
         &mut self,
         conn: &mut Self::Exec,
     ) -> impl Future<Output = Result<(), replay::Error>> + Send;
+
+    /// Clear the projection's view so it can be rebuilt from history.
+    ///
+    /// Called during a version-drift rebuild, before events are replayed through
+    /// [`handle`](Self::handle), inside the rebuild transaction. The default is a no-op;
+    /// projections that bump [`version`](Self::version) to trigger a rebuild should
+    /// override this to truncate their view, otherwise replay accumulates on top of the
+    /// existing data.
+    fn reset(
+        &mut self,
+        _conn: &mut Self::Exec,
+    ) -> impl Future<Output = Result<(), replay::Error>> + Send {
+        async { Ok(()) }
+    }
 
     /// Apply a batch of newly-appended events to the read model.
     ///
@@ -69,8 +91,16 @@ pub(crate) trait ErasedInlineProjection: Send + Sync {
 
     fn version(&self) -> i32;
 
+    fn stream_filter(&self) -> StreamFilter;
+
     fn init<'a>(&'a mut self, conn: &'a mut Self::Exec)
         -> BoxFuture<'a, Result<(), replay::Error>>;
+
+    /// Clear the underlying projection's view ahead of a rebuild.
+    fn reset<'a>(
+        &'a mut self,
+        conn: &'a mut Self::Exec,
+    ) -> BoxFuture<'a, Result<(), replay::Error>>;
 
     /// Route raw appended events to the underlying typed projection.
     ///
@@ -98,11 +128,22 @@ where
         InlineProjection::version(self)
     }
 
+    fn stream_filter(&self) -> StreamFilter {
+        InlineProjection::stream_filter(self)
+    }
+
     fn init<'a>(
         &'a mut self,
         conn: &'a mut Self::Exec,
     ) -> BoxFuture<'a, Result<(), replay::Error>> {
         Box::pin(InlineProjection::init(self, conn))
+    }
+
+    fn reset<'a>(
+        &'a mut self,
+        conn: &'a mut Self::Exec,
+    ) -> BoxFuture<'a, Result<(), replay::Error>> {
+        Box::pin(InlineProjection::reset(self, conn))
     }
 
     fn handle<'a>(

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -818,6 +818,161 @@ async fn bank_account_inline_projection_failure_rolls_back_postgres_test() {
     assert_eq!(projection_write_count, 0);
 }
 
+// ── Inline projection version drift rebuild (issue #60) ───────────────────────
+
+/// A balance view that resets and rebuilds from history on a version bump.
+///
+/// `version` is a field so the test can register the "same" projection at two
+/// different code versions to trigger a drift rebuild.
+struct RebuildBalanceProjection {
+    version: i32,
+}
+
+impl replay_persistence::InlineProjection for RebuildBalanceProjection {
+    type Exec = sqlx::PgConnection;
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "rebuild_balance_view"
+    }
+
+    fn version(&self) -> i32 {
+        self.version
+    }
+
+    async fn init(&mut self, conn: &mut Self::Exec) -> Result<(), replay::Error> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS rebuild_balances (
+                stream_id text PRIMARY KEY,
+                balance   double precision NOT NULL
+            )",
+        )
+        .execute(conn)
+        .await
+        .map_err(replay_persistence::db_error)?;
+        Ok(())
+    }
+
+    async fn reset(&mut self, conn: &mut Self::Exec) -> Result<(), replay::Error> {
+        sqlx::query("DELETE FROM rebuild_balances")
+            .execute(conn)
+            .await
+            .map_err(replay_persistence::db_error)?;
+        Ok(())
+    }
+
+    async fn handle(
+        &mut self,
+        conn: &mut Self::Exec,
+        events: &[PersistedEvent<Self::Event>],
+    ) -> Result<(), replay::Error> {
+        for event in events {
+            let delta = match &event.data {
+                BankAccountEvent::Deposited { amount, .. } => *amount,
+                BankAccountEvent::Withdrawn { amount, .. } => -*amount,
+                BankAccountEvent::MonthlyClosed { .. } => continue,
+            };
+
+            sqlx::query(
+                "INSERT INTO rebuild_balances (stream_id, balance)
+                 VALUES ($1, $2)
+                 ON CONFLICT (stream_id)
+                 DO UPDATE SET balance = rebuild_balances.balance + EXCLUDED.balance",
+            )
+            .bind(event.stream_id.to_string())
+            .bind(delta)
+            .execute(&mut *conn)
+            .await
+            .map_err(replay_persistence::db_error)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Re-registering a projection at a higher code version resets its view and rebuilds
+/// it by replaying history, recording the new version.
+#[tokio::test]
+async fn bank_account_inline_projection_version_drift_rebuild_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    // Build at version 1 and append history (deposit 100, withdraw 40 → balance 60).
+    let store = replay_persistence::PostgresEventStore::builder(pg_pool.clone())
+        .register(RebuildBalanceProjection { version: 1 })
+        .build()
+        .await
+        .expect("Failed to build store at projection version 1");
+
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let stream_id = BankAccountUrn::new("rebuild-1").unwrap();
+    let stream_id_str = Into::<Urn>::into(stream_id.clone()).to_string();
+
+    for command in [
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        BankAccountCommand::Withdraw {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 2).unwrap(),
+            amount: 40.0,
+        },
+    ] {
+        cqrs.execute::<BankAccount>(&stream_id, replay::Metadata::default(), command, &(), None)
+            .await
+            .unwrap();
+    }
+
+    // Corrupt the view with a sentinel value. If the rebuild fails to reset, the replay
+    // would accumulate on top of this (999 + 60 = 1059) instead of producing 60.
+    sqlx::query(
+        "INSERT INTO rebuild_balances (stream_id, balance) VALUES ($1, 999)
+         ON CONFLICT (stream_id) DO UPDATE SET balance = 999",
+    )
+    .bind(&stream_id_str)
+    .execute(&pg_pool)
+    .await
+    .expect("seeding sentinel balance must succeed");
+
+    // Re-register the same projection at version 2: triggers reset + replay rebuild.
+    let _store = replay_persistence::PostgresEventStore::builder(pg_pool.clone())
+        .register(RebuildBalanceProjection { version: 2 })
+        .build()
+        .await
+        .expect("Failed to rebuild store at projection version 2");
+
+    // The view was reset (sentinel 999 gone) and rebuilt from history (100 - 40 = 60).
+    let balance: f64 =
+        sqlx::query_scalar("SELECT balance FROM rebuild_balances WHERE stream_id = $1")
+            .bind(&stream_id_str)
+            .fetch_one(&pg_pool)
+            .await
+            .expect("rebuilt balance row must exist");
+
+    assert_eq!(balance, 60.0);
+
+    // The registry records the new code version.
+    let version: i32 = sqlx::query_scalar("SELECT version FROM projections WHERE name = $1")
+        .bind("rebuild_balance_view")
+        .fetch_one(&pg_pool)
+        .await
+        .expect("projection registry row must exist");
+
+    assert_eq!(version, 2);
+}
+
 // ── Scoped-URN types used by the tests below ─────────────────────────────────
 
 /// A branch that owns one or more bank accounts.

--- a/persistence/tests/migrations/0005_replay_indexes.sql
+++ b/persistence/tests/migrations/0005_replay_indexes.sql
@@ -1,0 +1,20 @@
+-- Indexes supporting inline-projection rebuild (replay) and the general event query API.
+--
+-- Both `PostgresEventStore::stream_events` and the projection drift-rebuild replay
+-- (`load_events_for_replay`) read events with:
+--
+--   SELECT ... FROM events WHERE <filter> ORDER BY created, version ASC
+--
+-- 1. events(created, version)
+--    Supports the ORDER BY for replays that scan a broad slice of history
+--    (e.g. StreamFilter::All or stream-type filters), letting Postgres return rows
+--    in order via an index scan instead of a full sequential scan + sort.
+CREATE INDEX IF NOT EXISTS idx_events_created_version
+    ON events (created, version);
+
+-- 2. streams(type)
+--    A projection's natural replay filter is `for_stream_type` -> ForStreamTypes,
+--    whose SQL resolves stream ids via `SELECT id FROM streams WHERE type IN (...)`.
+--    This index avoids scanning the whole streams table for that lookup.
+CREATE INDEX IF NOT EXISTS idx_streams_type
+    ON streams (type);


### PR DESCRIPTION
Closes #60

Automatically rebuilds an inline projection when its code `version()` is newer than the version recorded in the store.

## What
- Add `InlineProjection::reset` (default no-op) and `stream_filter() -> StreamFilter` (default `All`) to the trait, plumbed through the erased registry trait.
- `build()` now handles version drift: when `stored < code`, it `reset`s the view, replays matching history through `handle`, then writes the new version row **last** — all in one transaction, so a crash mid-rebuild never marks a half-built view as current.
- New `load_events_for_replay` helper scans events using the projection's `stream_filter`, ordered by `created, version` (single batch for now; chunking can follow without changing `handle` semantics).

## Indexes (migration 0005)
Targeted at the replay/query path:
- `events(created, version)` — supports the `ORDER BY created, version` used by replay and the existing `stream_events` API (avoids a full scan + sort on broad replays).
- `streams(type)` — supports the `ForStreamTypes` filter's `SELECT id FROM streams WHERE type IN (...)` lookup (the natural `for_stream_type` projection filter).
Existing `stream_id`/`aggregate_version` filters are already covered by migration 0002 indexes.

## Test
- `bank_account_inline_projection_version_drift_rebuild_postgres_test`: registers a projection at v1, appends events (balance 60), **seeds a sentinel 999** into the view, re-registers at v2, then asserts the view was reset (sentinel gone, not 1059) and rebuilt from history (60), with the registry version recorded as 2.
- Full persistence integration suite passes (13 tests).

## Scope notes
- The `stored == code` no-op fast path and the `stored > code` hard-error guard + startup logging are #62 (which is unblocked by this PR).
- No behavior change for first-time registration.