### PR TITLE
feat(persistence): inline projection version guard + startup logging (#62)

### DIFF
--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -240,15 +240,6 @@ impl PostgresEventStoreBuilder {
 
     /// Run setup for the registered projections and freeze the store.
     ///
-    /// For each projection:
-    /// - **First registration** (no stored version): run `init` and record the version.
-    /// - **Version drift** (stored version older than the code version): `reset` the view,
-    ///   replay matching history through `handle`, then update the stored version **last**,
-    ///   all in the same transaction so a crash mid-rebuild never marks a half-built view
-    ///   as current.
-    ///
-    /// Run setup for the registered projections and freeze the store.
-    ///
     /// For each projection, compares the stored registry version against the code
     /// [`version`](InlineProjection::version):
     /// - **First registration** (no stored version): run `init` and record the version.

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -247,17 +247,30 @@ impl PostgresEventStoreBuilder {
     ///   all in the same transaction so a crash mid-rebuild never marks a half-built view
     ///   as current.
     ///
-    /// The stored-equals-code no-op fast path and the stored-newer-than-code guard are
-    /// added by a later slice; here those cases simply register without changes.
+    /// Run setup for the registered projections and freeze the store.
+    ///
+    /// For each projection, compares the stored registry version against the code
+    /// [`version`](InlineProjection::version):
+    /// - **First registration** (no stored version): run `init` and record the version.
+    /// - **Drift** (`stored < code`): `reset` the view, replay matching history through
+    ///   `handle`, then update the stored version **last**, all in the same transaction so
+    ///   a crash mid-rebuild never marks a half-built view as current.
+    /// - **No-op** (`stored == code`): do nothing — no reset, no replay, no side effects.
+    /// - **Guard** (`stored > code`): return a hard error and refuse to start, so a
+    ///   rolled-back/older deploy can't corrupt a view built by newer code.
+    ///
+    /// Emits startup logs across the lifecycle (init, drift detection, reset, replay) so
+    /// operators can see what happens at startup.
     pub async fn build(self) -> Result<PostgresEventStore, replay::Error> {
         let mut tx = self.pool.begin().await.map_err(crate::db_error)?;
 
         let mut registered: Vec<RegisteredProjection> = Vec::with_capacity(self.projections.len());
 
         for mut projection in self.projections {
+            let name = projection.name().to_string();
             let stored: Option<i32> =
                 sqlx::query_scalar("SELECT version FROM projections WHERE name = $1")
-                    .bind(projection.name())
+                    .bind(&name)
                     .fetch_optional(&mut *tx)
                     .await
                     .map_err(crate::db_error)?;
@@ -267,10 +280,16 @@ impl PostgresEventStoreBuilder {
             match stored {
                 // First-time registration: create the view and record the version.
                 None => {
+                    tracing::info!(
+                        projection = %name,
+                        version = code,
+                        "inline projection first-time registration: running init"
+                    );
+
                     projection.init(&mut tx).await?;
 
                     sqlx::query("INSERT INTO projections (name, version) VALUES ($1, $2)")
-                        .bind(projection.name())
+                        .bind(&name)
                         .bind(code)
                         .execute(&mut *tx)
                         .await
@@ -281,12 +300,13 @@ impl PostgresEventStoreBuilder {
                 // never marks a half-built view as current.
                 Some(stored) if stored < code => {
                     tracing::info!(
-                        projection = projection.name(),
+                        projection = %name,
                         stored,
                         code,
-                        "inline projection version drift: resetting and replaying history"
+                        "inline projection version drift detected: rebuilding"
                     );
 
+                    tracing::info!(projection = %name, "inline projection reset: clearing view");
                     projection.reset(&mut tx).await?;
 
                     // Replay matching history through the projection. The projection's
@@ -295,18 +315,39 @@ impl PostgresEventStoreBuilder {
                     // batch-handling semantics seen by `handle`.
                     let events =
                         Self::load_events_for_replay(&mut tx, projection.stream_filter()).await?;
+                    tracing::info!(
+                        projection = %name,
+                        events = events.len(),
+                        "inline projection replay: applying history"
+                    );
                     projection.handle(&mut tx, &events).await?;
 
                     sqlx::query("UPDATE projections SET version = $2 WHERE name = $1")
-                        .bind(projection.name())
+                        .bind(&name)
                         .bind(code)
                         .execute(&mut *tx)
                         .await
                         .map_err(crate::db_error)?;
                 }
-                // stored == code (no-op fast path) and stored > code (guard) are handled by
-                // a later slice; registering without changes preserves existing behavior.
-                Some(_) => {}
+                // Stored version is newer than the code: refuse to start. A rolled-back or
+                // older deploy must not run against a view built by newer code.
+                Some(stored) if stored > code => {
+                    return Err(replay::Error::invalid_input(
+                        "inline projection stored version is newer than code version",
+                    )
+                    .with_operation("build")
+                    .with_context("projection", name)
+                    .with_context("stored_version", stored)
+                    .with_context("code_version", code));
+                }
+                // stored == code: no-op fast path. No reset, no replay, no side effects.
+                Some(_) => {
+                    tracing::debug!(
+                        projection = %name,
+                        version = code,
+                        "inline projection up to date: no rebuild"
+                    );
+                }
             }
 
             registered.push(Mutex::new(projection));

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -973,6 +973,129 @@ async fn bank_account_inline_projection_version_drift_rebuild_postgres_test() {
     assert_eq!(version, 2);
 }
 
+// ── Inline projection version guard + no-op fast path (issue #62) ─────────────
+
+/// Building with a stored version NEWER than the code version is a hard error: a
+/// rolled-back or older deploy must not run against a view built by newer code.
+#[tokio::test]
+async fn bank_account_inline_projection_stored_newer_than_code_errors_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    // First registration at version 2 records stored version = 2.
+    let _store = replay_persistence::PostgresEventStore::builder(pg_pool.clone())
+        .register(RebuildBalanceProjection { version: 2 })
+        .build()
+        .await
+        .expect("Failed to build store at projection version 2");
+
+    // Building at version 1 (older code than the stored view) must refuse to start.
+    let result = replay_persistence::PostgresEventStore::builder(pg_pool.clone())
+        .register(RebuildBalanceProjection { version: 1 })
+        .build()
+        .await;
+
+    assert!(
+        result.is_err(),
+        "build must fail when stored version is newer than code version"
+    );
+
+    // The registry version is untouched: the guard does not downgrade the stored view.
+    let version: i32 = sqlx::query_scalar("SELECT version FROM projections WHERE name = $1")
+        .bind("rebuild_balance_view")
+        .fetch_one(&pg_pool)
+        .await
+        .expect("projection registry row must exist");
+
+    assert_eq!(version, 2);
+}
+
+/// Re-building at the SAME code version is a no-op: no reset, no replay, no side
+/// effects. A sentinel seeded into the view survives the rebuild.
+#[tokio::test]
+async fn bank_account_inline_projection_same_version_is_noop_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    // Build at version 1 and append history (deposit 100, withdraw 40 → balance 60).
+    let store = replay_persistence::PostgresEventStore::builder(pg_pool.clone())
+        .register(RebuildBalanceProjection { version: 1 })
+        .build()
+        .await
+        .expect("Failed to build store at projection version 1");
+
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let stream_id = BankAccountUrn::new("noop-1").unwrap();
+    let stream_id_str = Into::<Urn>::into(stream_id.clone()).to_string();
+
+    for command in [
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        BankAccountCommand::Withdraw {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 2).unwrap(),
+            amount: 40.0,
+        },
+    ] {
+        cqrs.execute::<BankAccount>(&stream_id, replay::Metadata::default(), command, &(), None)
+            .await
+            .unwrap();
+    }
+
+    // Seed a sentinel value. A no-op rebuild leaves it untouched; a reset+replay would
+    // wipe it and recompute 60.
+    sqlx::query(
+        "INSERT INTO rebuild_balances (stream_id, balance) VALUES ($1, 999)
+         ON CONFLICT (stream_id) DO UPDATE SET balance = 999",
+    )
+    .bind(&stream_id_str)
+    .execute(&pg_pool)
+    .await
+    .expect("seeding sentinel balance must succeed");
+
+    // Re-register the same projection at the SAME version 1: must be a no-op.
+    let _store = replay_persistence::PostgresEventStore::builder(pg_pool.clone())
+        .register(RebuildBalanceProjection { version: 1 })
+        .build()
+        .await
+        .expect("Failed to rebuild store at the same projection version");
+
+    // The sentinel survives: no reset, no replay ran.
+    let balance: f64 =
+        sqlx::query_scalar("SELECT balance FROM rebuild_balances WHERE stream_id = $1")
+            .bind(&stream_id_str)
+            .fetch_one(&pg_pool)
+            .await
+            .expect("sentinel balance row must exist");
+
+    assert_eq!(balance, 999.0);
+}
+
 // ── Scoped-URN types used by the tests below ─────────────────────────────────
 
 /// A branch that owns one or more bank accounts.


### PR DESCRIPTION
Closes #62

## What

Builds on the version-drift rebuild (#60) by completing the registration lifecycle in `PostgresEventStoreBuilder::build()`:

- **Hard guard (`stored > code`)**: when a projection's stored registry version is newer than its code version, `build()` returns an error and the store does not start. This prevents a rolled-back or older deploy from corrupting a view built by newer code.
- **No-op fast path (`stored == code`)**: no reset, no replay, no side effects.
- **Startup logging**: explicit logs across the lifecycle — first-time init, drift detection, reset, and replay.

## Tests

- `bank_account_inline_projection_stored_newer_than_code_errors_postgres_test`: registers at v2, then builds at v1 and asserts `build()` errors and the stored version is left untouched.
- `bank_account_inline_projection_same_version_is_noop_postgres_test`: seeds a sentinel into the view, rebuilds at the same version, and asserts the sentinel survives (proving no reset/replay).

15 integration tests pass; fmt + clippy clean.