### PR TITLE
feat(persistence): replay backlog on first inline projection registration

### DIFF
--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -242,7 +242,9 @@ impl PostgresEventStoreBuilder {
     ///
     /// For each projection, compares the stored registry version against the code
     /// [`version`](InlineProjection::version):
-    /// - **First registration** (no stored version): run `init` and record the version.
+    /// - **First registration** (no stored version): run `init`, replay matching history
+    ///   through `handle` so the new projection catches up to the existing backlog, then
+    ///   record the version **last**, all in the same transaction.
     /// - **Drift** (`stored < code`): `reset` the view, replay matching history through
     ///   `handle`, then update the stored version **last**, all in the same transaction so
     ///   a crash mid-rebuild never marks a half-built view as current.
@@ -269,7 +271,9 @@ impl PostgresEventStoreBuilder {
             let code = projection.version();
 
             match stored {
-                // First-time registration: create the view and record the version.
+                // First-time registration: create the view, replay existing history so the
+                // new projection catches up to the backlog, then record the version LAST so a
+                // crash mid-replay never marks a half-built view as current.
                 None => {
                     tracing::info!(
                         projection = %name,
@@ -278,6 +282,19 @@ impl PostgresEventStoreBuilder {
                     );
 
                     projection.init(&mut tx).await?;
+
+                    // Replay matching history through the projection so a projection added to
+                    // a store that already contains events catches up to the full backlog
+                    // (not just events appended after registration). The projection's
+                    // stream_filter narrows which events are scanned.
+                    let events =
+                        Self::load_events_for_replay(&mut tx, projection.stream_filter()).await?;
+                    tracing::info!(
+                        projection = %name,
+                        events = events.len(),
+                        "inline projection replay: applying history for new projection"
+                    );
+                    projection.handle(&mut tx, &events).await?;
 
                     sqlx::query("INSERT INTO projections (name, version) VALUES ($1, $2)")
                         .bind(&name)

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -1096,6 +1096,81 @@ async fn bank_account_inline_projection_same_version_is_noop_postgres_test() {
     assert_eq!(balance, 999.0);
 }
 
+// ── Inline projection first-registration backlog replay (issue #71) ───────────
+
+/// Registering a brand-new projection against a store that already contains events
+/// replays the existing backlog so the view catches up — not just future events.
+#[tokio::test]
+async fn bank_account_inline_projection_first_registration_replays_backlog_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    // Build a store with NO projections registered and append history
+    // (deposit 100, withdraw 40 → balance 60). The projection does not exist yet.
+    let store = replay_persistence::PostgresEventStore::builder(pg_pool.clone())
+        .build()
+        .await
+        .expect("Failed to build store without projections");
+
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let stream_id = BankAccountUrn::new("backlog-1").unwrap();
+    let stream_id_str = Into::<Urn>::into(stream_id.clone()).to_string();
+
+    for command in [
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        BankAccountCommand::Withdraw {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 2).unwrap(),
+            amount: 40.0,
+        },
+    ] {
+        cqrs.execute::<BankAccount>(&stream_id, replay::Metadata::default(), command, &(), None)
+            .await
+            .unwrap();
+    }
+
+    // Register the projection for the FIRST time against the store that already has
+    // events. First registration must replay the backlog through `handle`.
+    let _store = replay_persistence::PostgresEventStore::builder(pg_pool.clone())
+        .register(RebuildBalanceProjection { version: 1 })
+        .build()
+        .await
+        .expect("Failed to build store with first-time projection registration");
+
+    // The view reflects the full backlog (100 - 40 = 60), not an empty/future-only state.
+    let balance: f64 =
+        sqlx::query_scalar("SELECT balance FROM rebuild_balances WHERE stream_id = $1")
+            .bind(&stream_id_str)
+            .fetch_one(&pg_pool)
+            .await
+            .expect("backlog-replayed balance row must exist");
+
+    assert_eq!(balance, 60.0);
+
+    // The registry records the projection version.
+    let version: i32 = sqlx::query_scalar("SELECT version FROM projections WHERE name = $1")
+        .bind("rebuild_balance_view")
+        .fetch_one(&pg_pool)
+        .await
+        .expect("projection registry row must exist");
+
+    assert_eq!(version, 1);
+}
+
 // ── Scoped-URN types used by the tests below ─────────────────────────────────
 
 /// A branch that owns one or more bank accounts.


### PR DESCRIPTION
## Summary

Fixes #71. When an inline projection is registered for the **first time** against a Postgres store that already contains events, `PostgresEventStoreBuilder::build()` now replays the existing matching history so the new projection catches up to the backlog — instead of starting empty and only seeing future events.

## Changes

- In the `None` (first-time registration) arm of `build()`: after `init`, load matching history via `load_events_for_replay` (respecting the projection's `stream_filter`) and apply it through `handle`, then record the version **last** — all within the same transaction. This mirrors the existing version-drift (`stored < code`) arm.
- Startup logging for the first-registration replay ("applying history for new projection").
- Updated the `build()` doc comment.

## Testing

- New integration test `bank_account_inline_projection_first_registration_replays_backlog_postgres_test`: appends events to a store with **no** projections, then registers a brand-new projection and asserts the view reflects the full backlog (100 − 40 = 60) and the registry records the version.
- `cargo fmt` + `cargo clippy --workspace --all-targets -D warnings` pass.
- Core/persistence non-Docker tests pass locally; Postgres integration tests run in CI (Docker unavailable locally).

Closes #71