### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["es", "macros", "persistence", "macros-tests"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Carlos Verdes <cverdes@gmail.com>"]
 license = "MIT"

--- a/macros-tests/Cargo.toml
+++ b/macros-tests/Cargo.toml
@@ -12,8 +12,8 @@ readme.workspace = true
 name = "replay_macros_tests"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.3.0" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.3.0" }
+replay = { package = "es-replay", path = "../es", version = "0.4.0" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.4.0" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 name = "replay_macros"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.3.0" }
+replay = { package = "es-replay", path = "../es", version = "0.4.0" }
 proc-macro2 = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }

--- a/persistence/Cargo.toml
+++ b/persistence/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["lib"]
 name = "replay_persistence"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.3.0" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.3.0" }
+replay = { package = "es-replay", path = "../es", version = "0.4.0" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.4.0" }
 
 serde = { workspace = true }
 serde_with = { workspace = true }


### PR DESCRIPTION
## Summary

Release **0.4.0**: completes the inline-projections epic (#57).

Bumps the workspace and all internal crate-dependency versions `0.3.0 → 0.4.0`:
- `es-replay`
- `es-replay-macros`
- `es-replay-persistence`
- `es-replay-macros-tests`

## What's in 0.4.0

Inline projections — persisted read models written inside the same Postgres transaction that appends events:
- Inline projection walking skeleton + atomic write (#58)
- Atomic rollback when a projection `handle` fails (#59)
- `append_event` returns the persisted row (#63)
- Version-drift reset + replay (#60)
- Version guard + startup logging (#62)
- Replay existing backlog on first registration (#71)
- Best-effort inline projections in the in-memory store (#61)

The git tag, GitHub release (with the new migration SQL for 0.3.0 → 0.4.0 upgrades), and crates.io publish follow once this merges.

`cargo check --workspace` + `cargo clippy` pass at 0.4.0.