### PR TITLE
feat(persistence): support ForStreamTypes in in-memory store with bank-account walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,14 @@ URN (`UserUrn`, `BankAccountUrn`), and the command/event enums (`UserCommand`,
 `UserEvent`, …). You provide the `EventStream` (how events fold into state) and
 `Aggregate` (how commands produce events) implementations.
 
+The URN namespace auto-derives from the type name (`User` → `"user"`), so it only
+needs to be set explicitly when you want something other than the default — as
+`BankAccount` does below.
+
 ```rust
 define_aggregate! {
     User {
-        namespace: "user",
+        // namespace auto-derives from the type name: `User` -> "user".
         state: {
             name: String,
         },
@@ -106,7 +110,9 @@ account → owner from that event.
 ```rust
 define_aggregate! {
     BankAccount {
-        namespace: "bank-account",
+        // Override the default "bank-account" with the shorter "account",
+        // so URNs read `urn:account:alice-checking`.
+        namespace: "account",
         state: {
             owner: Option<UserUrn>,
             balance: f64,

--- a/README.md
+++ b/README.md
@@ -32,14 +32,15 @@ different ways so the trade-offs are visible side by side:
 > working code. Run the live half (no database required) with
 > `cargo run -p es-replay-persistence --example global_position`.
 
-We import the traits and macros explicitly rather than glob-importing
-`replay_persistence::prelude::*`: that prelude re-exports `Result`/`Error`, which
-would shadow the `std`/`serde` names the derive macros expand to.
+We glob-import `replay::prelude::*` to bring the core traits (`Aggregate`,
+`EventStream`, `Compactable`, …) into scope, but import from `replay_persistence`
+explicitly: its prelude re-exports `Result`/`Error`, which would shadow the
+`std`/`serde` names the derive macros expand to.
 
 ```rust
 use std::collections::HashSet;
 
-use replay::{prelude::*, Compactable};
+use replay::prelude::*;
 use replay_macros::{define_aggregate, query_events};
 use replay_persistence::{db_error, InlineProjection, PersistedEvent, Query, StreamFilter};
 ```

--- a/README.md
+++ b/README.md
@@ -297,9 +297,15 @@ impl Query for GlobalPositionQuery {
 **Strategy 2 — a materialised inline projection.** `GlobalPositionProjection`
 maintains the same read model in two Postgres tables, written inside the very same
 transaction that appends the events. Reads become a single indexed `SELECT`, paid
-for with schema, versioning, and write-time cost. (See the full `init`/`handle`
-implementations in
+for with schema, versioning, and write-time cost. (See the full `handle`
+implementation in
 [persistence/examples/global_position.rs](persistence/examples/global_position.rs).)
+
+The view tables are owned by a migration, not created from `init`. Prefer driving
+schema from your migration history over running DDL in `init` — it keeps table
+creation and evolution auditable instead of coupling it to registration. So `init`
+stays a no-op here, and the tables come from
+[persistence/tests/migrations/0006_global_position_projection.sql](persistence/tests/migrations/0006_global_position_projection.sql).
 
 ```rust
 pub struct GlobalPositionProjection;
@@ -316,10 +322,9 @@ impl InlineProjection for GlobalPositionProjection {
         1
     }
 
-    async fn init(&mut self, conn: &mut Self::Exec) -> replay::Result<()> {
-        // CREATE TABLE gp_account_owner (account_urn PK, user_urn) and
-        // gp_user_position (user_urn PK, name, total_balance) — see the example file.
-        # let _ = conn;
+    async fn init(&mut self, _conn: &mut Self::Exec) -> replay::Result<()> {
+        // The view tables are created by a SQL migration, not here. Running DDL
+        // from `init` is discouraged because it bypasses your migration history.
         Ok(())
     }
 

--- a/README.md
+++ b/README.md
@@ -14,94 +14,76 @@ You can chose you implement just `Stream` (state will be built from events) or `
 
 ## Example
 
-Let's assume we have a bank account with a balance that is updated when there is a deposit or withdrawal.
+Let's model a small banking domain with two aggregate roots:
 
-Our domain would look something like this:
+- **`User`** — a person who can register and own accounts.
+- **`BankAccount`** — an account opened *for* a user that money flows in and out of.
+
+From those events we build the same read model — a user's **global position**
+(their name plus the summed balance of every account they own) — in two
+different ways so the trade-offs are visible side by side:
+
+- a **live** [`Query`] folded in memory on every read, and
+- an **inline** [`InlineProjection`] materialised into Postgres inside the append transaction.
+
+> The full, compilable source for everything below lives in
+> [persistence/examples/global_position.rs](persistence/examples/global_position.rs)
+> and is exercised by the integration tests, so the README stays in lock-step with
+> working code. Run the live half (no database required) with
+> `cargo run -p es-replay-persistence --example global_position`.
+
+We import the traits and macros explicitly rather than glob-importing
+`replay_persistence::prelude::*`: that prelude re-exports `Result`/`Error`, which
+would shadow the `std`/`serde` names the derive macros expand to.
 
 ```rust
-use replay::Stream;
-use replay_macros::Event;
-use serde::{Deserialize, Serialize};
-use urn::Urn;
+use std::collections::HashSet;
 
-//  bank account is an aggregate (id of aggregate is now part of the model)
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
-struct BankAccountAggregate {
-    pub id: BankAccountUrn,
-    pub balance: f64,
-}
+use replay::{prelude::*, Compactable};
+use replay_macros::{define_aggregate, query_events};
+use replay_persistence::{db_error, InlineProjection, PersistedEvent, Query, StreamFilter};
+```
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
-enum BankAccountCommand {
-    Deposit { amount: f64 },
-    Withdraw { amount: f64 },
-}
+### Defining the aggregates
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Event)]
-enum BankAccountEvent {
-    Deposited { amount: f64 },
-    Withdrawn { amount: f64 },
-}
+The `define_aggregate!` macro generates the aggregate struct, its strongly-typed
+URN (`UserUrn`, `BankAccountUrn`), and the command/event enums (`UserCommand`,
+`UserEvent`, …). You provide the `EventStream` (how events fold into state) and
+`Aggregate` (how commands produce events) implementations.
 
-// recommended to create an specific type for the aggregate id
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-struct BankAccountUrn(Urn);
-
-impl From<BankAccountUrn> for Urn {
-    fn from(urn: BankAccountUrn) -> Self {
-        urn.0
-    }
-}
-
-impl TryFrom<Urn> for BankAccountUrn {
-    type Error = String;
-
-    fn try_from(urn: Urn) -> Result<Self, Self::Error> {
-        if urn.nid() == "bank-account" {
-            Ok(BankAccountUrn(urn))
-        } else {
-            Err(format!("Invalid namespace: expected 'bank-account', got '{}'", urn.nid()))
+```rust
+define_aggregate! {
+    User {
+        namespace: "user",
+        state: {
+            name: String,
+        },
+        commands: {
+            Register { name: String },
+        },
+        events: {
+            Registered { name: String },
         }
     }
 }
 
-#[derive(Debug, Error)]
-enum BankAccountError {
-    #[error("Insufficient funds")]
-    InsufficientFunds,
-    #[error("Persistence error: {source}")]
-    PersistenceError {
-        #[from]
-        source: replay::persistence::EventStoreError,
-    },
-}
-
-// to create an aggregate we need first to implement Stream trait
-impl replay::Stream for BankAccountAggregate {
-    type Event = BankAccountEvent;
-    type StreamId = BankAccountUrn;
+impl EventStream for User {
+    type Event = UserEvent;
 
     fn stream_type() -> String {
-        "BankAccount".to_string()
+        "User".to_string()
     }
 
-    // as you can see this method can't fail and has no side effects
     fn apply(&mut self, event: Self::Event) {
         match event {
-            BankAccountEvent::Deposited { amount } => {
-                self.balance += amount;
-            }
-            BankAccountEvent::Withdrawn { amount } => {
-                self.balance -= amount;
-            }
+            UserEvent::Registered { name } => self.name = name,
         }
     }
 }
 
-// the aggregate trait handles the commands / business logic rules / error management etc.
-impl replay::Aggregate for BankAccountAggregate {
-    type Command = BankAccountCommand;
-    type Error = BankAccountError;
+impl Aggregate for User {
+    type Command = UserCommand;
+    type Error = replay::Error;
     type Services = ();
 
     async fn handle(
@@ -110,102 +92,306 @@ impl replay::Aggregate for BankAccountAggregate {
         _services: &Self::Services,
     ) -> replay::Result<Vec<Self::Event>> {
         match command {
+            UserCommand::Register { name } => Ok(vec![UserEvent::Registered { name }]),
+        }
+    }
+}
+```
+
+A `BankAccount` is opened *for* a user: the `OpenAccount` command only references
+the owning root by its URN, it never reaches into the `User` aggregate. Only
+`AccountOpened` carries the owner; movements stay lean and the read models resolve
+account → owner from that event.
+
+```rust
+define_aggregate! {
+    BankAccount {
+        namespace: "bank-account",
+        state: {
+            owner: Option<UserUrn>,
+            balance: f64,
+        },
+        commands: {
+            OpenAccount { owner: UserUrn },
+            Deposit { amount: f64 },
+            Withdraw { amount: f64 },
+            CloseMonth { month: chrono::NaiveDate },
+        },
+        events: {
+            AccountOpened { owner: UserUrn },
+            Deposited { amount: f64 },
+            Withdrawn { amount: f64 },
+            MonthlyClosed { month: chrono::NaiveDate, closing_balance: f64 },
+        }
+    }
+}
+
+impl EventStream for BankAccount {
+    type Event = BankAccountEvent;
+
+    fn stream_type() -> String {
+        "BankAccount".to_string()
+    }
+
+    fn apply(&mut self, event: Self::Event) {
+        match event {
+            BankAccountEvent::AccountOpened { owner } => self.owner = Some(owner),
+            BankAccountEvent::Deposited { amount } => self.balance += amount,
+            BankAccountEvent::Withdrawn { amount } => self.balance -= amount,
+            // A checkpoint replaces the running balance with the closing one, so a
+            // compacted stream rehydrates to exactly the same state.
+            BankAccountEvent::MonthlyClosed { closing_balance, .. } => {
+                self.balance = closing_balance
+            }
+        }
+    }
+}
+
+impl Aggregate for BankAccount {
+    type Command = BankAccountCommand;
+    type Error = replay::Error;
+    type Services = ();
+
+    async fn handle(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> replay::Result<Vec<Self::Event>> {
+        match command {
+            BankAccountCommand::OpenAccount { owner } => {
+                Ok(vec![BankAccountEvent::AccountOpened { owner }])
+            }
             BankAccountCommand::Deposit { amount } => {
-                let event = BankAccountEvent::Deposited { amount };
-                Ok(vec![event])
+                Ok(vec![BankAccountEvent::Deposited { amount }])
             }
             BankAccountCommand::Withdraw { amount } => {
                 if self.balance < amount {
-                    return Err(BankAccountError::InsufficientFunds);
+                    return Err(replay::Error::business_rule_violation("Insufficient funds")
+                        .with_operation("Withdraw")
+                        .with_context("amount_tried", amount));
                 }
-
-                let event = BankAccountEvent::Withdrawn { amount };
-                Ok(vec![event])
+                Ok(vec![BankAccountEvent::Withdrawn { amount }])
             }
+            BankAccountCommand::CloseMonth { month } => Ok(vec![BankAccountEvent::MonthlyClosed {
+                month,
+                closing_balance: self.balance,
+            }]),
         }
-    }
-
-    fn with_id(id: Self::StreamId) -> Self {
-        Self { 
-            id,
-            balance: 0.0 
-        }
-    }
-
-    fn id(&self) -> &Self::StreamId {
-        &self.id
     }
 }
 ```
 
-### Aggregate Identity Pattern
+### Compaction
 
-Aggregates in DDD must always have an identity. The `Aggregate` trait enforces this through:
-
-- **`StreamId`**: Inherited from `EventStream`, a strongly-typed identifier that must implement `Into<Urn>`, `TryFrom<Urn>`, `Clone`, and `PartialEq`
-- **`with_id(id)`**: Required constructor that creates an aggregate with an identity
-- **`with_string_id(urn_string)`**: Convenience constructor that parses a URN string
-- **`id()`**: Returns a reference to the aggregate's identity
-
-This design ensures aggregates are always created with a valid URN-based identity, following DDD principles.
+Implement `Compactable` to keep streams short. Each `MonthlyClosed` snapshots the
+balance, so everything before the most recent checkpoint is redundant once the
+balance is replaced on replay — a compacted stream rehydrates to exactly the same
+state.
 
 ```rust
-// Create aggregate with typed id
-let bank_id = BankAccountUrn(UrnBuilder::new("bank-account", "123").build().unwrap());
-let aggregate = BankAccountAggregate::with_id(bank_id);
-
-// Create aggregate from URN string
-let aggregate = BankAccountAggregate::with_string_id("urn:bank-account:456").unwrap();
-
-// Access the aggregate's id
-println!("Aggregate ID: {}", aggregate.id());
+impl Compactable for BankAccount {
+    async fn compacted_events(
+        &self,
+        events: impl futures::TryStream<Ok = BankAccountEvent, Error = replay::Error> + Send,
+    ) -> replay::Result<Vec<BankAccountEvent>> {
+        use futures::TryStreamExt;
+        events
+            .try_fold(Vec::new(), |mut tail, event| async move {
+                if matches!(event, BankAccountEvent::MonthlyClosed { .. }) {
+                    tail.clear();
+                }
+                tail.push(event);
+                Ok(tail)
+            })
+            .await
+    }
+}
 ```
 
-Now we can create a Postgres store and start storing aggregates:
+### A cross-aggregate read model
+
+`query_events!` builds one merged event type so a single reader can consume both
+streams. Its `Deserialize` impl tries each underlying type in turn
+(deserialize-or-skip), which is how unrelated events are filtered out during a
+fold or while routing to an inline projection.
 
 ```rust
-// connect to Postgres
-let pg_pool = PgPoolOptions::new()
-    .max_connections(50)
-    .idle_timeout(std::time::Duration::from_secs(5))
-    .connect(&format!(
-        "postgres://postgres:postgres@{}:{}/postgres",
-        host, port
-    ))
-    .await
-    .expect("Failed to create postgres pool");
+query_events!(GlobalPositionEvent => [UserEvent, BankAccountEvent]);
 
-// create an event store
-let store = replay::persistence::PostgresEventStore::new(pg_pool);
+/// A user's name together with the summed balance of every account they own.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct GlobalPosition {
+    pub name: String,
+    pub total_balance: f64,
+}
+```
 
-let bank_id = BankAccountUrn(UrnBuilder::new("bank-account", "1").build().unwrap());
+**Strategy 1 — a live query.** `GlobalPositionQuery` folds history on demand.
+Because deposits and withdrawals do not carry the owner, it first learns which
+accounts belong to the user (from `AccountOpened`) and then applies only the
+movements on those accounts. The `stream_filter` is a hint the store pushes down
+where it can; nothing is stored, so every read folds the matched log from the
+start.
 
-let commands = vec![
-    BankAccountCommand::Deposit { amount: 100.0 },
-    BankAccountCommand::Withdraw { amount: 40.0 },
-];
-
-// Create aggregate with id
-let mut bank_account = BankAccountAggregate::with_id(bank_id.clone());
-
-let services = &();
-let expected_version = None;
-
-for command in commands {
-    let events = bank_account.handle(command, services).await.unwrap();
-    bank_account.apply_all(events);
+```rust
+pub struct GlobalPositionQuery {
+    user: UserUrn,
+    owned_accounts: HashSet<urn::Urn>,
+    position: GlobalPosition,
 }
 
-assert_eq!(bank_account.balance, 60.0);
+impl GlobalPositionQuery {
+    pub fn for_user(user: UserUrn) -> Self {
+        Self {
+            user,
+            owned_accounts: HashSet::new(),
+            position: GlobalPosition::default(),
+        }
+    }
 
-// if we try to withdraw again we will get a business error (InsufficientFunds)
-let result = bank_account.handle(
-    BankAccountCommand::Withdraw { amount: 100.0 },
-    services
-).await;
+    pub fn position(&self) -> &GlobalPosition {
+        &self.position
+    }
+}
 
-assert!(result.is_err());
+impl Query for GlobalPositionQuery {
+    type Event = GlobalPositionEvent;
+
+    fn stream_filter(&self) -> StreamFilter {
+        StreamFilter::with_stream_id::<User>(&self.user)
+            .or(StreamFilter::for_stream_type::<BankAccount>())
+    }
+
+    fn update(&mut self, event: PersistedEvent<Self::Event>) {
+        match event.data {
+            GlobalPositionEvent::UserEvent(UserEvent::Registered { name }) => {
+                self.position.name = name;
+            }
+            GlobalPositionEvent::BankAccountEvent(BankAccountEvent::AccountOpened { owner }) => {
+                if owner == self.user {
+                    self.owned_accounts.insert(event.stream_id);
+                }
+            }
+            GlobalPositionEvent::BankAccountEvent(BankAccountEvent::Deposited { amount }) => {
+                if self.owned_accounts.contains(&event.stream_id) {
+                    self.position.total_balance += amount;
+                }
+            }
+            GlobalPositionEvent::BankAccountEvent(BankAccountEvent::Withdrawn { amount }) => {
+                if self.owned_accounts.contains(&event.stream_id) {
+                    self.position.total_balance -= amount;
+                }
+            }
+            GlobalPositionEvent::BankAccountEvent(BankAccountEvent::MonthlyClosed { .. }) => {}
+        }
+    }
+}
 ```
+
+**Strategy 2 — a materialised inline projection.** `GlobalPositionProjection`
+maintains the same read model in two Postgres tables, written inside the very same
+transaction that appends the events. Reads become a single indexed `SELECT`, paid
+for with schema, versioning, and write-time cost. (See the full `init`/`handle`
+implementations in
+[persistence/examples/global_position.rs](persistence/examples/global_position.rs).)
+
+```rust
+pub struct GlobalPositionProjection;
+
+impl InlineProjection for GlobalPositionProjection {
+    type Exec = sqlx::PgConnection;
+    type Event = GlobalPositionEvent;
+
+    fn name(&self) -> &str {
+        "global_position"
+    }
+
+    fn version(&self) -> i32 {
+        1
+    }
+
+    async fn init(&mut self, conn: &mut Self::Exec) -> replay::Result<()> {
+        // CREATE TABLE gp_account_owner (account_urn PK, user_urn) and
+        // gp_user_position (user_urn PK, name, total_balance) — see the example file.
+        # let _ = conn;
+        Ok(())
+    }
+
+    async fn handle(
+        &mut self,
+        conn: &mut Self::Exec,
+        events: &[PersistedEvent<Self::Event>],
+    ) -> replay::Result<()> {
+        // Upsert names from Registered, account→owner from AccountOpened, and add
+        // each Deposited/Withdrawn delta to the owner's running total.
+        # let _ = (conn, events);
+        Ok(())
+    }
+}
+```
+
+### Driving it with CQRS
+
+`Cqrs` wraps an event store. `execute` runs a command (load → handle → append),
+`fetch_aggregate` rehydrates a single aggregate, and `run_query` folds a live
+query across the streams its filter matches. The live half needs no database, so
+it runs against the in-memory store:
+
+```rust
+use replay_persistence::{Cqrs, InMemoryEventStore};
+
+let cqrs = Cqrs::new(InMemoryEventStore::new());
+
+// Register a user.
+let alice = UserUrn::new("alice").unwrap();
+cqrs.execute::<User>(
+    &alice,
+    Default::default(),
+    UserCommand::Register { name: "Alice".to_string() },
+    &(),
+    None,
+)
+.await?;
+
+// Open two accounts for Alice and move some money around.
+let checking = BankAccountUrn::new("alice-checking").unwrap();
+let savings = BankAccountUrn::new("alice-savings").unwrap();
+
+for account in [&checking, &savings] {
+    cqrs.execute::<BankAccount>(
+        account,
+        Default::default(),
+        BankAccountCommand::OpenAccount { owner: alice.clone() },
+        &(),
+        None,
+    )
+    .await?;
+}
+
+cqrs.execute::<BankAccount>(&checking, Default::default(),
+    BankAccountCommand::Deposit { amount: 1_000.0 }, &(), None).await?;
+cqrs.execute::<BankAccount>(&checking, Default::default(),
+    BankAccountCommand::Withdraw { amount: 250.0 }, &(), None).await?;
+cqrs.execute::<BankAccount>(&savings, Default::default(),
+    BankAccountCommand::Deposit { amount: 500.0 }, &(), None).await?;
+
+// A single account always knows its own balance straight from the aggregate.
+let checking_account = cqrs.fetch_aggregate::<BankAccount>(&checking).await?;
+assert_eq!(checking_account.balance, 750.0);
+
+// The global position spans every account Alice owns. Here it is folded live.
+let mut position = GlobalPositionQuery::for_user(alice.clone());
+cqrs.run_query::<_, GlobalPositionEvent>(&mut position).await?;
+
+assert_eq!(position.position().name, "Alice");
+assert_eq!(position.position().total_balance, 1_250.0); // 1000 - 250 + 500
+```
+
+Swap `InMemoryEventStore` for `PostgresEventStore` and register
+`GlobalPositionProjection` to have the same numbers materialised inside the append
+transaction — the integration test
+`global_position_live_query_and_inline_projection_agree_postgres_test` proves both
+strategies produce an identical `GlobalPosition`.
 
 ## Using Macros
 
@@ -314,7 +500,7 @@ enum BankAccountError {
     #[error("Persistence error: {source}")]
     PersistenceError {
         #[from]
-        source: replay::persistence::EventStoreError,
+        source: replay::Error,
     },
 }
 

--- a/persistence/examples/global_position.rs
+++ b/persistence/examples/global_position.rs
@@ -30,7 +30,9 @@ use std::collections::HashSet;
 // NOTE: we import the traits and macros explicitly rather than glob-importing
 // `replay_persistence::prelude::*`. That prelude re-exports `Result`/`Error`,
 // which would shadow the `std`/`serde` names the derive macros expand to.
-use replay::{prelude::*, Compactable};
+// `replay::prelude` is safe to glob: it brings in the core traits
+// (`Aggregate`, `EventStream`, `Compactable`, …) without those names.
+use replay::prelude::*;
 use replay_macros::{define_aggregate, query_events};
 use replay_persistence::{db_error, InlineProjection, PersistedEvent, Query, StreamFilter};
 

--- a/persistence/examples/global_position.rs
+++ b/persistence/examples/global_position.rs
@@ -1,0 +1,494 @@
+//! End-to-end tour of the `replay` event-sourcing toolkit using a small banking
+//! domain. It is the runnable companion to the example at the top of the README,
+//! so the two are kept in lock-step.
+//!
+//! The domain has two aggregate roots:
+//!
+//! * [`User`] — a person who can register and own accounts.
+//! * [`BankAccount`] — an account opened *for* a user that money flows in and out of.
+//!
+//! From those events we build the same read model — a user's **global position**
+//! (their name plus the summed balance of every account they own) — in two
+//! different ways so the trade-offs are visible side by side:
+//!
+//! * a [`Query`] folded **live** in memory on every read, and
+//! * an [`InlineProjection`] **materialised** into Postgres inside the append
+//!   transaction.
+//!
+//! Run the live half (no database required) with:
+//!
+//! ```bash
+//! cargo run -p es-replay-persistence --example global_position
+//! ```
+//!
+//! The inline-projection half needs Postgres, so it is exercised by the
+//! Docker-gated integration test `global_position_*_postgres_test`; here it is
+//! defined so it type-checks under `cargo build --examples`.
+
+use std::collections::HashSet;
+
+// NOTE: we import the traits and macros explicitly rather than glob-importing
+// `replay_persistence::prelude::*`. That prelude re-exports `Result`/`Error`,
+// which would shadow the `std`/`serde` names the derive macros expand to.
+use replay::{prelude::*, Compactable};
+use replay_macros::{define_aggregate, query_events};
+use replay_persistence::{db_error, InlineProjection, PersistedEvent, Query, StreamFilter};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// User aggregate
+// ─────────────────────────────────────────────────────────────────────────────
+
+define_aggregate! {
+    User {
+        namespace: "user",
+        state: {
+            name: String,
+        },
+        commands: {
+            Register { name: String },
+        },
+        events: {
+            Registered { name: String },
+        }
+    }
+}
+
+impl EventStream for User {
+    type Event = UserEvent;
+
+    fn stream_type() -> String {
+        "User".to_string()
+    }
+
+    fn apply(&mut self, event: Self::Event) {
+        match event {
+            UserEvent::Registered { name } => self.name = name,
+        }
+    }
+}
+
+impl Aggregate for User {
+    type Command = UserCommand;
+    type Error = replay::Error;
+    type Services = ();
+
+    async fn handle(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> replay::Result<Vec<Self::Event>> {
+        match command {
+            UserCommand::Register { name } => Ok(vec![UserEvent::Registered { name }]),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BankAccount aggregate
+// ─────────────────────────────────────────────────────────────────────────────
+
+define_aggregate! {
+    BankAccount {
+        namespace: "bank-account",
+        state: {
+            owner: Option<UserUrn>,
+            balance: f64,
+        },
+        commands: {
+            // An account is opened *for* a user: the command only references the
+            // owning root by its URN, it never reaches into the User aggregate.
+            OpenAccount { owner: UserUrn },
+            Deposit { amount: f64 },
+            Withdraw { amount: f64 },
+            CloseMonth { month: chrono::NaiveDate },
+        },
+        events: {
+            // Only `AccountOpened` carries the owner; movements stay lean and the
+            // read models resolve account -> owner from this event.
+            AccountOpened { owner: UserUrn },
+            Deposited { amount: f64 },
+            Withdrawn { amount: f64 },
+            MonthlyClosed { month: chrono::NaiveDate, closing_balance: f64 },
+        }
+    }
+}
+
+impl EventStream for BankAccount {
+    type Event = BankAccountEvent;
+
+    fn stream_type() -> String {
+        "BankAccount".to_string()
+    }
+
+    fn apply(&mut self, event: Self::Event) {
+        match event {
+            BankAccountEvent::AccountOpened { owner } => self.owner = Some(owner),
+            BankAccountEvent::Deposited { amount } => self.balance += amount,
+            BankAccountEvent::Withdrawn { amount } => self.balance -= amount,
+            // A checkpoint replaces the running balance with the closing one, so a
+            // compacted stream rehydrates to exactly the same state.
+            BankAccountEvent::MonthlyClosed {
+                closing_balance, ..
+            } => self.balance = closing_balance,
+        }
+    }
+}
+
+impl Aggregate for BankAccount {
+    type Command = BankAccountCommand;
+    type Error = replay::Error;
+    type Services = ();
+
+    async fn handle(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> replay::Result<Vec<Self::Event>> {
+        match command {
+            BankAccountCommand::OpenAccount { owner } => {
+                Ok(vec![BankAccountEvent::AccountOpened { owner }])
+            }
+            BankAccountCommand::Deposit { amount } => {
+                Ok(vec![BankAccountEvent::Deposited { amount }])
+            }
+            BankAccountCommand::Withdraw { amount } => {
+                if self.balance < amount {
+                    return Err(replay::Error::business_rule_violation("Insufficient funds")
+                        .with_operation("Withdraw")
+                        .with_context("amount_tried", amount));
+                }
+                Ok(vec![BankAccountEvent::Withdrawn { amount }])
+            }
+            BankAccountCommand::CloseMonth { month } => Ok(vec![BankAccountEvent::MonthlyClosed {
+                month,
+                closing_balance: self.balance,
+            }]),
+        }
+    }
+}
+
+impl Compactable for BankAccount {
+    async fn compacted_events(
+        &self,
+        events: impl futures::TryStream<Ok = BankAccountEvent, Error = replay::Error> + Send,
+    ) -> replay::Result<Vec<BankAccountEvent>> {
+        use futures::TryStreamExt;
+        // Keep only the tail after the most recent monthly checkpoint: each
+        // `MonthlyClosed` snapshots the balance, so everything before it is
+        // redundant once we replace the balance on replay.
+        events
+            .try_fold(Vec::new(), |mut tail, event| async move {
+                if matches!(event, BankAccountEvent::MonthlyClosed { .. }) {
+                    tail.clear();
+                }
+                tail.push(event);
+                Ok(tail)
+            })
+            .await
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cross-aggregate read model: a user's global position
+// ─────────────────────────────────────────────────────────────────────────────
+
+// One merged event type lets a single reader consume both streams. Its
+// `Deserialize` impl tries each underlying type in turn (deserialize-or-skip),
+// which is exactly how unrelated events are filtered out during a fold or while
+// routing to an inline projection.
+query_events!(GlobalPositionEvent => [UserEvent, BankAccountEvent]);
+
+/// A user's name together with the summed balance of every account they own.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct GlobalPosition {
+    pub name: String,
+    pub total_balance: f64,
+}
+
+// ── Strategy 1: a live in-memory query ───────────────────────────────────────
+
+/// Computes [`GlobalPosition`] for a single user by folding history on demand.
+///
+/// Because deposits and withdrawals do not carry the owner, the query first learns
+/// which accounts belong to the user (from `AccountOpened`) and then applies only
+/// the movements on those accounts.
+///
+/// Trade-off: nothing is stored, so every read folds the log from the start.
+pub struct GlobalPositionQuery {
+    user: UserUrn,
+    owned_accounts: HashSet<urn::Urn>,
+    position: GlobalPosition,
+}
+
+impl GlobalPositionQuery {
+    pub fn for_user(user: UserUrn) -> Self {
+        Self {
+            user,
+            owned_accounts: HashSet::new(),
+            position: GlobalPosition::default(),
+        }
+    }
+
+    pub fn position(&self) -> &GlobalPosition {
+        &self.position
+    }
+}
+
+impl Query for GlobalPositionQuery {
+    type Event = GlobalPositionEvent;
+
+    fn stream_filter(&self) -> StreamFilter {
+        // Read this user's own stream plus every bank-account stream, then resolve
+        // ownership from the events themselves. The filter is a hint the store
+        // pushes down where it can; the live strategy still rescans the matched
+        // history on every read.
+        StreamFilter::with_stream_id::<User>(&self.user)
+            .or(StreamFilter::for_stream_type::<BankAccount>())
+    }
+
+    fn update(&mut self, event: PersistedEvent<Self::Event>) {
+        match event.data {
+            GlobalPositionEvent::UserEvent(UserEvent::Registered { name }) => {
+                self.position.name = name;
+            }
+            GlobalPositionEvent::BankAccountEvent(BankAccountEvent::AccountOpened { owner }) => {
+                if owner == self.user {
+                    self.owned_accounts.insert(event.stream_id);
+                }
+            }
+            GlobalPositionEvent::BankAccountEvent(BankAccountEvent::Deposited { amount }) => {
+                if self.owned_accounts.contains(&event.stream_id) {
+                    self.position.total_balance += amount;
+                }
+            }
+            GlobalPositionEvent::BankAccountEvent(BankAccountEvent::Withdrawn { amount }) => {
+                if self.owned_accounts.contains(&event.stream_id) {
+                    self.position.total_balance -= amount;
+                }
+            }
+            GlobalPositionEvent::BankAccountEvent(BankAccountEvent::MonthlyClosed { .. }) => {}
+        }
+    }
+}
+
+// ── Strategy 2: a materialised inline projection ─────────────────────────────
+
+/// Maintains the global position for every user in two Postgres tables, written
+/// inside the same transaction that appends the events.
+///
+/// * `gp_account_owner` maps an account URN to its owning user URN.
+/// * `gp_user_position` holds each user's name and running total balance.
+///
+/// The events live in a single stream table; the normalised read model brings the
+/// classic owner/account/position join back. Trade-off: reads are a single indexed
+/// `SELECT`, paid for with schema, versioning, and write-time cost.
+pub struct GlobalPositionProjection;
+
+impl InlineProjection for GlobalPositionProjection {
+    type Exec = sqlx::PgConnection;
+    type Event = GlobalPositionEvent;
+
+    fn name(&self) -> &str {
+        "global_position"
+    }
+
+    fn version(&self) -> i32 {
+        1
+    }
+
+    async fn init(&mut self, conn: &mut Self::Exec) -> replay::Result<()> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gp_account_owner (
+                 account_urn text PRIMARY KEY,
+                 user_urn    text NOT NULL
+             )",
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(db_error)?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS gp_user_position (
+                 user_urn      text PRIMARY KEY,
+                 name          text NOT NULL DEFAULT '',
+                 total_balance double precision NOT NULL DEFAULT 0
+             )",
+        )
+        .execute(&mut *conn)
+        .await
+        .map_err(db_error)?;
+
+        Ok(())
+    }
+
+    async fn handle(
+        &mut self,
+        conn: &mut Self::Exec,
+        events: &[PersistedEvent<Self::Event>],
+    ) -> replay::Result<()> {
+        for event in events {
+            match &event.data {
+                GlobalPositionEvent::UserEvent(UserEvent::Registered { name }) => {
+                    sqlx::query(
+                        "INSERT INTO gp_user_position (user_urn, name)
+                         VALUES ($1, $2)
+                         ON CONFLICT (user_urn) DO UPDATE SET name = EXCLUDED.name",
+                    )
+                    .bind(event.stream_id.to_string())
+                    .bind(name)
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(db_error)?;
+                }
+                GlobalPositionEvent::BankAccountEvent(BankAccountEvent::AccountOpened {
+                    owner,
+                }) => {
+                    sqlx::query(
+                        "INSERT INTO gp_account_owner (account_urn, user_urn)
+                         VALUES ($1, $2)
+                         ON CONFLICT (account_urn) DO UPDATE SET user_urn = EXCLUDED.user_urn",
+                    )
+                    .bind(event.stream_id.to_string())
+                    .bind(owner.to_string())
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(db_error)?;
+
+                    // Make sure the owner has a position row even before any movement.
+                    sqlx::query(
+                        "INSERT INTO gp_user_position (user_urn)
+                         VALUES ($1)
+                         ON CONFLICT (user_urn) DO NOTHING",
+                    )
+                    .bind(owner.to_string())
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(db_error)?;
+                }
+                GlobalPositionEvent::BankAccountEvent(BankAccountEvent::Deposited { amount }) => {
+                    apply_balance_delta(conn, &event.stream_id, *amount).await?;
+                }
+                GlobalPositionEvent::BankAccountEvent(BankAccountEvent::Withdrawn { amount }) => {
+                    apply_balance_delta(conn, &event.stream_id, -*amount).await?;
+                }
+                GlobalPositionEvent::BankAccountEvent(BankAccountEvent::MonthlyClosed {
+                    ..
+                }) => {}
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Add `delta` to the running balance of whichever user owns `account_urn`.
+async fn apply_balance_delta(
+    conn: &mut sqlx::PgConnection,
+    account_urn: &urn::Urn,
+    delta: f64,
+) -> replay::Result<()> {
+    sqlx::query(
+        "UPDATE gp_user_position
+            SET total_balance = total_balance + $1
+          WHERE user_urn = (
+              SELECT user_urn FROM gp_account_owner WHERE account_urn = $2
+          )",
+    )
+    .bind(delta)
+    .bind(account_urn.to_string())
+    .execute(conn)
+    .await
+    .map_err(db_error)?;
+
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Runnable walkthrough (live query, no database required)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Gated out of the `cfg(test)` build so this file can be `#[path]`-included as a
+// module by the Docker-gated integration test, which drives the same types
+// against Postgres and provides its own test harness.
+#[cfg(not(test))]
+#[tokio::main]
+async fn main() -> replay::Result<()> {
+    use replay_persistence::{Cqrs, InMemoryEventStore};
+
+    let cqrs = Cqrs::new(InMemoryEventStore::new());
+
+    // Register a user.
+    let alice = UserUrn::new("alice").unwrap();
+    cqrs.execute::<User>(
+        &alice,
+        Default::default(),
+        UserCommand::Register {
+            name: "Alice".to_string(),
+        },
+        &(),
+        None,
+    )
+    .await?;
+
+    // Open two accounts for Alice and move some money around.
+    let checking = BankAccountUrn::new("alice-checking").unwrap();
+    let savings = BankAccountUrn::new("alice-savings").unwrap();
+
+    for account in [&checking, &savings] {
+        cqrs.execute::<BankAccount>(
+            account,
+            Default::default(),
+            BankAccountCommand::OpenAccount {
+                owner: alice.clone(),
+            },
+            &(),
+            None,
+        )
+        .await?;
+    }
+
+    cqrs.execute::<BankAccount>(
+        &checking,
+        Default::default(),
+        BankAccountCommand::Deposit { amount: 1_000.0 },
+        &(),
+        None,
+    )
+    .await?;
+    cqrs.execute::<BankAccount>(
+        &checking,
+        Default::default(),
+        BankAccountCommand::Withdraw { amount: 250.0 },
+        &(),
+        None,
+    )
+    .await?;
+    cqrs.execute::<BankAccount>(
+        &savings,
+        Default::default(),
+        BankAccountCommand::Deposit { amount: 500.0 },
+        &(),
+        None,
+    )
+    .await?;
+
+    // A single account always knows its own balance straight from the aggregate.
+    let checking_account = cqrs.fetch_aggregate::<BankAccount>(&checking).await?;
+    println!("checking balance: {}", checking_account.balance);
+
+    // The global position spans every account Alice owns. Here it is folded live.
+    let mut position = GlobalPositionQuery::for_user(alice.clone());
+    cqrs.run_query::<_, GlobalPositionEvent>(&mut position)
+        .await?;
+
+    println!(
+        "global position for {}: {} across all accounts",
+        position.position().name,
+        position.position().total_balance,
+    );
+
+    assert_eq!(position.position().name, "Alice");
+    assert_eq!(position.position().total_balance, 1_250.0);
+
+    Ok(())
+}

--- a/persistence/examples/global_position.rs
+++ b/persistence/examples/global_position.rs
@@ -40,7 +40,8 @@ use replay_persistence::{db_error, InlineProjection, PersistedEvent, Query, Stre
 
 define_aggregate! {
     User {
-        namespace: "user",
+        // No `namespace`: it auto-derives from the type name (`User` -> "user"),
+        // so `UserUrn::new("alice")` yields `urn:user:alice`.
         state: {
             name: String,
         },
@@ -89,7 +90,10 @@ impl Aggregate for User {
 
 define_aggregate! {
     BankAccount {
-        namespace: "bank-account",
+        // Override the namespace: the type name would auto-derive to
+        // "bank-account", but we pin the shorter "account" so URNs read
+        // `urn:account:alice-checking`.
+        namespace: "account",
         state: {
             owner: Option<UserUrn>,
             balance: f64,

--- a/persistence/examples/global_position.rs
+++ b/persistence/examples/global_position.rs
@@ -286,6 +286,12 @@ impl Query for GlobalPositionQuery {
 /// The events live in a single stream table; the normalised read model brings the
 /// classic owner/account/position join back. Trade-off: reads are a single indexed
 /// `SELECT`, paid for with schema, versioning, and write-time cost.
+///
+/// The view tables are owned by a SQL migration
+/// (`tests/migrations/0006_global_position_projection.sql`), not created here.
+/// Prefer migrations over DDL in [`init`](InlineProjection::init): they keep
+/// schema creation and evolution in your auditable migration history instead of
+/// coupling it to projection registration.
 pub struct GlobalPositionProjection;
 
 impl InlineProjection for GlobalPositionProjection {
@@ -300,28 +306,12 @@ impl InlineProjection for GlobalPositionProjection {
         1
     }
 
-    async fn init(&mut self, conn: &mut Self::Exec) -> replay::Result<()> {
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS gp_account_owner (
-                 account_urn text PRIMARY KEY,
-                 user_urn    text NOT NULL
-             )",
-        )
-        .execute(&mut *conn)
-        .await
-        .map_err(db_error)?;
-
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS gp_user_position (
-                 user_urn      text PRIMARY KEY,
-                 name          text NOT NULL DEFAULT '',
-                 total_balance double precision NOT NULL DEFAULT 0
-             )",
-        )
-        .execute(&mut *conn)
-        .await
-        .map_err(db_error)?;
-
+    async fn init(&mut self, _conn: &mut Self::Exec) -> replay::Result<()> {
+        // No-op: the `gp_account_owner` / `gp_user_position` tables are created by
+        // a migration, not here. Running schema DDL from `init` is discouraged
+        // because it bypasses your migration history; manage the view schema with
+        // your migration tool and keep `init` empty (or for one-off setup that
+        // genuinely can't live in a migration).
         Ok(())
     }
 

--- a/persistence/src/infrastructure/in_memory_store.rs
+++ b/persistence/src/infrastructure/in_memory_store.rs
@@ -13,10 +13,13 @@ use replay::{Compactable, Event};
 
 /// In-memory event store implementation, only for testing purpose.
 ///
-/// It ignores stream type.
-///
 /// Events are stored per-stream-URN in insertion order. The `aggregate_version` field on each
 /// event distinguishes current events (`None`) from archived compaction snapshots (`Some(n)`).
+///
+/// Stream filters are normally *pushed down* to the database; the in-memory store has no
+/// schema to push down to, so it evaluates every filter as a per-event predicate instead. To
+/// support [`StreamFilter::ForStreamTypes`] it records each stream's type on append (the type
+/// is stable per stream URN) and matches against it while scanning.
 ///
 /// The store can also run **best-effort inline projections** (test-only): after each
 /// successful append it routes the newly-appended events to every registered projection's
@@ -26,6 +29,9 @@ use replay::{Compactable, Event};
 /// routing and batch-handling logic in fast unit tests without a database.
 pub struct InMemoryEventStore {
     events: RwLock<HashMap<Urn, Vec<PersistedEvent<Value>>>>,
+    /// Stream type per stream URN, recorded on append so [`StreamFilter::ForStreamTypes`] can
+    /// be evaluated per-event without a database to push the filter down to.
+    stream_types: RwLock<HashMap<Urn, String>>,
     /// Best-effort inline projections, applied after events are appended. Each projection is
     /// locked individually while it handles a batch. The in-memory store passes a unit (`()`)
     /// write handle, so projections must keep their view in their own state (e.g. shared via
@@ -37,6 +43,7 @@ impl InMemoryEventStore {
     pub fn new() -> Self {
         Self {
             events: RwLock::new(HashMap::new()),
+            stream_types: RwLock::new(HashMap::new()),
             projections: Vec::new(),
         }
     }
@@ -96,34 +103,35 @@ impl InMemoryEventStore {
 
     /// Apply a filter to a raw (un-typed) persisted event.
     ///
-    /// Returns an error if the filter contains a `ForStreamTypes` variant — that variant
-    /// requires knowledge of the concrete `EventStream` type at compile time, which is not
-    /// available when working with the raw JSON storage of the in-memory store.
+    /// Every [`StreamFilter`] variant is evaluated as a per-event predicate. `stream_type` is
+    /// the type of the stream the event belongs to (resolved from the store's side map); it is
+    /// only needed by [`StreamFilter::ForStreamTypes`].
     fn evaluate<E>(
         filter: &StreamFilter,
         event: &PersistedEvent<E>,
-    ) -> Result<bool, replay::Error> {
+        stream_type: Option<&str>,
+    ) -> bool {
         match filter {
-            StreamFilter::All => Ok(true),
-            StreamFilter::WithStreamId(stream_id) => Ok(event.stream_id == *stream_id),
-            StreamFilter::ForStreamTypes(_) => Err(replay::Error::internal(
-                "InMemoryEventStore does not support ForStreamTypes filters; \
-                 use stream_events_by_stream_id with a concrete EventStream type instead",
-            )
-            .with_operation("stream_events")),
-            StreamFilter::WithMetadata(metadata) => Ok(event.metadata == *metadata),
-            StreamFilter::AfterVersion(version) => Ok(event.version > *version),
-            StreamFilter::UpToVersion(version) => Ok(event.version <= *version),
-            StreamFilter::CreatedAfter(timestamp) => Ok(event.created > *timestamp),
-            StreamFilter::CreatedBefore(timestamp) => Ok(event.created <= *timestamp),
-            StreamFilter::WithAggregateVersion(v) => Ok(event.aggregate_version == *v),
+            StreamFilter::All => true,
+            StreamFilter::WithStreamId(stream_id) => event.stream_id == *stream_id,
+            StreamFilter::ForStreamTypes(stream_types) => {
+                stream_type.is_some_and(|st| stream_types.iter().any(|t| t == st))
+            }
+            StreamFilter::WithMetadata(metadata) => event.metadata == *metadata,
+            StreamFilter::AfterVersion(version) => event.version > *version,
+            StreamFilter::UpToVersion(version) => event.version <= *version,
+            StreamFilter::CreatedAfter(timestamp) => event.created > *timestamp,
+            StreamFilter::CreatedBefore(timestamp) => event.created <= *timestamp,
+            StreamFilter::WithAggregateVersion(v) => event.aggregate_version == *v,
             StreamFilter::And(left, right) => {
-                Ok(Self::evaluate(left, event)? && Self::evaluate(right, event)?)
+                Self::evaluate(left, event, stream_type)
+                    && Self::evaluate(right, event, stream_type)
             }
             StreamFilter::Or(left, right) => {
-                Ok(Self::evaluate(left, event)? || Self::evaluate(right, event)?)
+                Self::evaluate(left, event, stream_type)
+                    || Self::evaluate(right, event, stream_type)
             }
-            StreamFilter::Not(inner) => Ok(!Self::evaluate(inner, event)?),
+            StreamFilter::Not(inner) => !Self::evaluate(inner, event, stream_type),
         }
     }
 }
@@ -138,12 +146,18 @@ impl EventStore for InMemoryEventStore {
     async fn store_events<S: replay::EventStream>(
         &self,
         stream_id: &S::StreamId,
-        _stream_type: String,
+        stream_type: String,
         metadata: replay::Metadata,
         domain_events: &[S::Event],
         expected_version: Option<i64>,
     ) -> Result<(), replay::Error> {
         let stream_id: Urn = stream_id.clone().into();
+
+        // Record the stream's type so `ForStreamTypes` filters can be evaluated per-event.
+        self.stream_types
+            .write()
+            .unwrap()
+            .insert(stream_id.clone(), stream_type);
 
         // Append under the write lock, then release it before driving any async projections
         // (the std `RwLockWriteGuard` is not held across an await).
@@ -224,21 +238,22 @@ impl EventStore for InMemoryEventStore {
         filter: StreamFilter,
     ) -> impl TryStream<Ok = PersistedEvent<E>, Error = replay::Error> + Send {
         // Optimise: if the filter references a specific stream URN, only scan that stream.
-        let candidate_events: Vec<PersistedEvent<Value>> = {
+        let (candidate_events, stream_types): (Vec<PersistedEvent<Value>>, HashMap<Urn, String>) = {
             let store = self.events.read().unwrap();
-            if let Some(stream_id) = Self::extract_stream_id(&filter) {
+            let stream_types = self.stream_types.read().unwrap().clone();
+            let events = if let Some(stream_id) = Self::extract_stream_id(&filter) {
                 store.get(&stream_id).cloned().unwrap_or_default()
             } else {
                 store.values().flatten().cloned().collect()
-            }
+            };
+            (events, stream_types)
         };
 
         async_stream::stream! {
             for event in candidate_events {
-                match Self::evaluate(&filter, &event) {
-                    Err(e) => { yield Err(e); return; }
-                    Ok(false) => continue,
-                    Ok(true) => {}
+                let stream_type = stream_types.get(&event.stream_id).map(String::as_str);
+                if !Self::evaluate(&filter, &event, stream_type) {
+                    continue;
                 }
                 let data: E = serde_json::from_value(event.data).map_err(crate::deser_error)?;
                 yield Ok(PersistedEvent {
@@ -664,6 +679,75 @@ mod tests {
         stream.apply_all(stream_events);
 
         assert_eq!(stream.balance, 60.0);
+    }
+
+    #[tokio::test]
+    async fn stream_events_filters_by_stream_type() {
+        let store = InMemoryEventStore::new();
+
+        let checking = make_stream_id("checking");
+        let savings = make_stream_id("savings");
+
+        // Two streams recorded under two different stream types. The in-memory store
+        // remembers each stream's type so it can evaluate `ForStreamTypes` per-event
+        // (there is no database to push the filter down to).
+        store
+            .store_events::<BankAccountStream>(
+                &checking,
+                "Checking".to_string(),
+                replay::Metadata::default(),
+                &[BankAccountEvent::Deposited { amount: 100.0 }],
+                None,
+            )
+            .await
+            .unwrap();
+        store
+            .store_events::<BankAccountStream>(
+                &savings,
+                "Savings".to_string(),
+                replay::Metadata::default(),
+                &[BankAccountEvent::Deposited { amount: 50.0 }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        // A single stream type matches only its own events instead of erroring.
+        let checking_only: Vec<BankAccountEvent> = store
+            .stream_events::<BankAccountEvent>(StreamFilter::ForStreamTypes(vec![
+                "Checking".to_string()
+            ]))
+            .map_ok(|e| e.data)
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            checking_only,
+            vec![BankAccountEvent::Deposited { amount: 100.0 }]
+        );
+
+        // Several stream types match the union of their events.
+        let both: Vec<BankAccountEvent> = store
+            .stream_events::<BankAccountEvent>(StreamFilter::ForStreamTypes(vec![
+                "Checking".to_string(),
+                "Savings".to_string(),
+            ]))
+            .map_ok(|e| e.data)
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(both.len(), 2);
+
+        // A stream type nobody was stored under matches nothing.
+        let none: Vec<BankAccountEvent> = store
+            .stream_events::<BankAccountEvent>(StreamFilter::ForStreamTypes(vec![
+                "Unknown".to_string()
+            ]))
+            .map_ok(|e| e.data)
+            .try_collect()
+            .await
+            .unwrap();
+        assert!(none.is_empty());
     }
 
     // ── Best-effort inline projections (issue #61) ───────────────────────────

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -12,6 +12,13 @@ use replay::{prelude::*, Compactable};
 use replay_macros::{define_aggregate, Urn};
 use replay_persistence::{AggregateVersion, EventStore, PersistedEvent, StreamFilter};
 
+// Re-use the README walkthrough verbatim as the source of truth. The example's
+// `main` is gated `#[cfg(not(test))]`, so including it here pulls in only the
+// domain types, the live `GlobalPositionQuery`, and the inline
+// `GlobalPositionProjection`.
+#[path = "../examples/global_position.rs"]
+mod global_position;
+
 const POSTGRES_PORT: u16 = 5432;
 
 // ── Aggregate definition via macro ───────────────────────────────────────────
@@ -1267,4 +1274,106 @@ fn test_at_rejects_scoped_scope_urn() {
     let already_scoped_branch = BranchUrn(Urn::from_str("urn:branch:london@region:uk").unwrap());
     let err = account.at(&already_scoped_branch).unwrap_err();
     assert!(err.to_string().contains("scope URN is already scoped"));
+}
+
+// ── README global-position example: live query vs inline projection ──────────
+
+/// The two read-model strategies from the README walkthrough must agree.
+///
+/// The same `User` + `BankAccount` history is driven against Postgres while the
+/// inline [`GlobalPositionProjection`](global_position::GlobalPositionProjection)
+/// materialises a user's global position into SQL tables. Reading those tables
+/// must yield exactly the same name and total balance as folding the history live
+/// with [`GlobalPositionQuery`](global_position::GlobalPositionQuery).
+#[tokio::test]
+async fn global_position_live_query_and_inline_projection_agree_postgres_test() {
+    use global_position::{
+        BankAccount, BankAccountCommand, BankAccountUrn as AccountUrn, GlobalPositionEvent,
+        GlobalPositionProjection, GlobalPositionQuery, User, UserCommand, UserUrn,
+    };
+
+    let container = postgres::Postgres::default().start().await.unwrap();
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    // The projection's `init` creates the `gp_account_owner` / `gp_user_position` tables.
+    let store = replay_persistence::PostgresEventStore::builder(pg_pool.clone())
+        .register(GlobalPositionProjection)
+        .build()
+        .await
+        .expect("Failed to build store with the global-position projection");
+
+    let cqrs = replay_persistence::Cqrs::new(store);
+
+    let alice = UserUrn::new("alice").unwrap();
+    cqrs.execute::<User>(
+        &alice,
+        replay::Metadata::default(),
+        UserCommand::Register {
+            name: "Alice".to_string(),
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let checking = AccountUrn::new("alice-checking").unwrap();
+    let savings = AccountUrn::new("alice-savings").unwrap();
+
+    for account in [&checking, &savings] {
+        cqrs.execute::<BankAccount>(
+            account,
+            replay::Metadata::default(),
+            BankAccountCommand::OpenAccount {
+                owner: alice.clone(),
+            },
+            &(),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    for (account, command) in [
+        (&checking, BankAccountCommand::Deposit { amount: 1_000.0 }),
+        (&checking, BankAccountCommand::Withdraw { amount: 250.0 }),
+        (&savings, BankAccountCommand::Deposit { amount: 500.0 }),
+    ] {
+        cqrs.execute::<BankAccount>(account, replay::Metadata::default(), command, &(), None)
+            .await
+            .unwrap();
+    }
+
+    // Read the materialised inline projection.
+    let alice_urn = Into::<Urn>::into(alice.clone()).to_string();
+    let (inline_name, inline_balance): (String, f64) =
+        sqlx::query_as("SELECT name, total_balance FROM gp_user_position WHERE user_urn = $1")
+            .bind(&alice_urn)
+            .fetch_one(&pg_pool)
+            .await
+            .expect("inline projection must have a row for alice");
+
+    // Fold the same history live.
+    let mut live = GlobalPositionQuery::for_user(alice.clone());
+    cqrs.run_query::<_, GlobalPositionEvent>(&mut live)
+        .await
+        .unwrap();
+
+    // Both strategies agree, and agree with the hand-computed total (1000 - 250 + 500).
+    assert_eq!(inline_name, "Alice");
+    assert_eq!(inline_balance, 1_250.0);
+    assert_eq!(live.position().name, inline_name);
+    assert_eq!(live.position().total_balance, inline_balance);
 }

--- a/persistence/tests/migrations/0006_global_position_projection.sql
+++ b/persistence/tests/migrations/0006_global_position_projection.sql
@@ -1,0 +1,20 @@
+-- Schema for the `global_position` inline projection (README walkthrough).
+--
+-- The projection's view tables are owned here, in a migration, rather than being
+-- created from `InlineProjection::init`. Driving schema from your migration
+-- history (instead of DDL in `init`) keeps table creation, evolution, and
+-- rollback in one auditable place and avoids coupling schema lifecycle to
+-- projection registration. `init` is therefore left as a no-op in the example.
+--
+-- * `gp_account_owner` maps an account URN to its owning user URN.
+-- * `gp_user_position` holds each user's name and running total balance.
+CREATE TABLE IF NOT EXISTS gp_account_owner (
+    account_urn text PRIMARY KEY,
+    user_urn    text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS gp_user_position (
+    user_urn      text             PRIMARY KEY,
+    name          text             NOT NULL DEFAULT '',
+    total_balance double precision NOT NULL DEFAULT 0
+);


### PR DESCRIPTION
## Summary

Adds a compilable, macro-driven **bank-account + user** example as the single source of truth for the README opening, and makes the in-memory event store honour `ForStreamTypes` filters.

### Library change (`feat`)
The example surfaced that `InMemoryEventStore` rejected `ForStreamTypes` filters (silently dropping events during `run_query`). The store now records each stream's type on append and evaluates the filter per-event; filters still push down to the database where supported. Covered by a new unit test.

### Docs / example
- New `persistence/examples/global_position.rs` — two aggregate roots (`User`, `BankAccount`) defined via `define_aggregate!`, `Compactable` monthly compaction, a `query_events!` merged event type, and the same global-position read model built **two ways**: a live `Query` and an inline `InlineProjection`.
- README opening rewritten to mirror the example (the previous opener referenced `replay::Stream` and a nonexistent `replay::persistence::EventStoreError` and predated the macros).
- Docker-gated integration test `global_position_live_query_and_inline_projection_agree_postgres_test` drives the same history against Postgres and asserts the live query and inline projection produce an identical `GlobalPosition`.

## Validation
- `cargo run -p es-replay-persistence --example global_position` → `checking balance: 750` / `global position for Alice: 1250`
- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p es-replay-persistence --lib` → 17 passed
- Integration test compiles (`--no-run`); Postgres half runs in CI