### PR TITLE
feat(persistence): policy walking skeleton (#77)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,26 @@ A projection that updates an **external** system (for example a search index)
 process that compares projection progress against the event stream. Eventually
 consistent rather than strongly consistent. (Planned; not yet implemented.)
 
+### Policy
+
+An event-driven reaction in the event-sourcing domain: an appended event
+triggers a Policy, which issues a command that may raise further events. A
+Policy is **not** a [Projection] — it derives no read model; its output is a
+command and its effects are side effects on the write side. It runs in the
+background and is eventually consistent. Because a Policy re-executes side
+effects when it processes an event, it cannot be safely rebuilt by replaying
+history the way a versioned [Projection] can. (Planned; not yet implemented.)
+_Avoid_: reactor, saga, process manager, automation, trigger, reaction.
+
+### Causation
+
+The link from the event that triggered a [Policy] to the command and resulting
+events the Policy raises in response. The triggering event's identity is the
+stable key a target [Aggregate] uses to recognise a reaction it has already
+applied, and the chain of causation is what bounds how deep one event may
+cascade into further reactions.
+_Avoid_: trigger, cause, origin.
+
 ### Query
 
 The existing on-demand, in-memory fold over filtered events. It is the
@@ -60,7 +80,9 @@ single-threaded WASM environment (generated services use
 `es`/`macros` must preserve both arms. The `persistence` crate (Postgres + sqlx +
 tokio) is **server-only / non-WASM**, so every projection mechanism that lives
 there — including the [Inline projection] — is a native-only feature and is free
-to use `Send` bounds. A future [Async projection] aimed at client/edge targets
+to use `Send` bounds. A [Policy] is likewise native-only: its contract (the
+reaction itself) is portable, but its runtime is an irreducibly server-side
+background process. A future [Async projection] aimed at client/edge targets
 would need to honour the WASM dual-cfg pattern.
 
 [Aggregate]: #aggregate
@@ -68,3 +90,4 @@ would need to honour the WASM dual-cfg pattern.
 [Live projection]: #live-projection
 [Inline projection]: #inline-projection
 [Async projection]: #async-projection
+[Projection]: #projection

--- a/docs/adr/0001-inline-projection-architecture.md
+++ b/docs/adr/0001-inline-projection-architecture.md
@@ -11,7 +11,10 @@ them to each registered projection and only commits if every projection's
 projection and the events it derives from strongly consistent — they commit
 together or not at all — and means a projection is never behind the log, so no
 checkpoint or catch-up position is ever stored (the `projections` table records
-only a version, for rebuild detection).
+only a version, for rebuild detection). This "no stored position" property is
+specific to *inline* projections; a [Policy](0003-policies-as-checkpointed-background-subscribers.md),
+being an eventually-consistent background subscriber, necessarily does store a
+catch-up position.
 
 The registry of projections is **fixed at construction** via a builder
 (`PostgresEventStore::builder(pool).register(..).build().await?`). `build()` runs

--- a/docs/adr/0003-policies-as-checkpointed-background-subscribers.md
+++ b/docs/adr/0003-policies-as-checkpointed-background-subscribers.md
@@ -1,0 +1,111 @@
+# Policies are a checkpointed background subscriber, distinct from projections
+
+**Status:** accepted
+
+We add **Policies** — event-driven reactions where an appended event triggers a
+reaction that issues a command, which may raise further events. A Policy is
+**not** a projection: it derives no read model, its output is a command, and its
+effects are side effects on the write side. Projections and Policies happen to
+share one substrate — a **checkpointed background subscriber over the event log**
+(catch-up replay, a stored position, at-least-once delivery, global ordering) —
+but they are siblings on that substrate, not a parent/child. The umbrella term
+"Projection" stays honest (a derived *read model*); a command-issuing reaction is
+named separately so the two never leak requirements into each other.
+
+The defining asymmetry: a projection's rebuild is idempotent by construction
+(reset the view, re-fold), whereas a Policy's "rebuild" **re-executes side
+effects**. Therefore a **projection version bump ⇒ reset + replay**, but a
+**Policy version/code change ⇒ resume from the stored checkpoint, never replay**.
+
+## Decisions
+
+- **Start position** is an explicit per-policy choice, `start_at: Beginning | Now`,
+  defaulting to the *safe* `Now` (a newly registered policy does not retroactively
+  fire commands across all history unless asked). `Beginning` is the deliberate
+  backfill path. A version change never moves the position.
+- **Global cursor.** Policies are the first feature needing a total order over the
+  whole log. We add a `BIGSERIAL global_position` to `events` and read it with a
+  **high-water-mark** reader: advance only across a contiguous, gap-free prefix
+  (with a short visibility grace), so a sequence value that is assigned but not yet
+  committed by a concurrent append can never be skipped. We rejected an append-time
+  serializing lock (kills bulk-load write throughput) and a naive `created`/per-
+  stream `version` cursor (not a total order; skips and double-counts under clock
+  skew and concurrency).
+- **Delivery is at-least-once.** We do not chase exactly-once delivery (high cost,
+  illusory across crash boundaries). Correctness comes from **idempotent aggregate
+  commands** (at-least-once + idempotent consumer = effectively-once). The dedup key
+  is **causation** — the triggering event's identity — never command-value equality
+  (two structurally equal deposits must both apply). Idempotency is a contract we
+  *teach* (causation-guard recipe in the example aggregate, invariant-first trait
+  docs, and a duplicate-delivery integration test as executable proof), not a
+  compile-time marker trait — a marker would assert a property it cannot check, at
+  the wrong granularity (idempotency is per-command, not per-aggregate-type), and
+  would hand newcomers a confusing first error they would rubber-stamp away.
+- **Loop prevention** is orthogonal to idempotency (each turn of a loop is a *new*
+  event, so idempotency does not bound it). The author implicitly declares a DAG of
+  event → command → event that the library cannot verify (handlers are opaque; a
+  code change can introduce a back-edge). We carry a **causation depth** in metadata
+  and refuse to react past a configured maximum, acting as a runtime cycle-detector.
+  At the limit we **skip the event and log loudly** (with the causation chain and
+  the flags that change the behavior) while the policy keeps advancing — a circuit
+  breaker, not a poison pill. The depth limit resolves most-specific-first:
+  per-policy override → global env var → built-in default. We rejected provenance
+  filtering (policies ignoring policy-authored events) because cascading policies
+  are a wanted first-class use case.
+- **Runtime** is one long-lived `tokio` task per policy (the async-daemon shape) —
+  the honest analog of an actor without importing an actor framework, with the
+  cursor owned task-locally. Event discovery is **polling** as the correctness
+  baseline (works across disconnect/crash), with Postgres `LISTEN/NOTIFY` as an
+  optional latency hint layered on top (best-effort, never the source of truth).
+- **Single active runner per policy** via `pg_advisory_lock` (zero new
+  infrastructure; leader failover for free — a dead leader's session-scoped lock
+  releases and a standby resumes from the stored cursor). This is **not** a scaling
+  compromise: **global event order is a correctness property of policies**, and only
+  a single sequential consumer draining `global_position` in order preserves it.
+  Competing-consumers/partitioning (the Kafka model) gives only per-partition order
+  — which is exactly why Kafka is wrong for ordered event-sourced reactions. The
+  inherent cost is that a single ordered policy cannot be parallelized; an
+  order-indifferent policy could later opt *into* partitioning, but that is an
+  explicit per-policy opt-out of the guarantee, never the default.
+- **Batching.** Reads and cursor writes are batched, but a batch is a
+  checkpoint/commit boundary, **never** a parallelism boundary: within a batch,
+  events are applied strictly sequentially in `global_position` order. Durability is
+  one transaction per command execution (slow but safe); the cursor is written every
+  *K* committed commands. The **skip-safety rule**: the cursor only ever advances
+  across events whose commands are durably committed — a duplicate is harmless, a
+  skip is silent data loss. Batch sizes resolve per-policy → global env var →
+  default. (Batching multiple commands into one transaction is deferred to a
+  separate issue.)
+- **Failure handling** dispatches on the existing `ErrorKind`/`ErrorStatus` (which
+  already categorise by "what the caller can do"): `Temporary` → bounded retry with
+  backoff; `Conflict` (optimistic-concurrency) → reload and retry (the natural dedup
+  outcome of redelivery); `BusinessRuleViolation` → not a failure, the aggregate
+  legitimately declined, log and advance; permanent/exhausted → write a
+  `policy_dead_letters` row and advance (a *recorded* skip, never silent). Dead-
+  letter-and-advance is safe precisely because v1 policies are stateless per-event
+  reactions; a future stateful process manager would need halt-on-poison instead.
+- **Authoring API.** A `Policy` is a sibling of `Query`/`InlineProjection`: a
+  `query_events!`-merged `Event`, a stable `name`, a `stream_filter`, a `start_at`,
+  and a single `react(&self, event) -> Result<Vec<Dispatch>>`. `react` is a **pure
+  function of the event** — it returns typed `Dispatch::to::<A>(id, command)`
+  descriptors and the **runner** executes them, owning the `Cqrs`, stamping causation
+  and depth, applying optimistic concurrency, and dispatching errors. This keeps a
+  policy unit-testable with no database and prevents authors from smuggling reads or
+  out-of-band writes into a reaction. Aggregate `Services` are registered on the
+  runner (`register_services::<A>(..)`), never held by the policy. A closure
+  shortcut mirrors `register_postgres_event_handler` for the low-ceremony case.
+
+## Consequences
+
+- Policies are **native-only**, living in the server-only `persistence` crate and
+  free to use `Send`/`BoxFuture`. The `Policy` *trait* and `Dispatch` descriptor are
+  kept free of Postgres/tokio types so they remain a portable contract; the *runner*
+  is the swappable, currently-native-only runtime. Supporting policies on WASM
+  (single-instance, no leader election, local event log, `spawn_local`, `?Send`) is a
+  second runner over the same contract and is deferred to its own issue.
+- Archived (compacted) events become load-bearing for policies that may still need to
+  walk pre-compaction history; see ADR-0004 for how the policy feed reads the true log
+  across compaction.
+- The compaction-versus-lagging-policy interaction and the duplicate-delivery,
+  loop-limit, and failover behaviours are covered by Docker-gated Postgres
+  integration tests, which double as the executable specification of these contracts.

--- a/docs/adr/0004-compaction-synthetic-event-marker-for-policy-feed.md
+++ b/docs/adr/0004-compaction-synthetic-event-marker-for-policy-feed.md
@@ -1,0 +1,47 @@
+# Compaction marks synthetic events so a lagging Policy reads the true log
+
+**Status:** accepted
+
+A [Policy](0003-policies-as-checkpointed-background-subscribers.md) must process
+every *real* event exactly once, in global order, even when it lags behind a
+compaction. Compaction (`compact`) does **not** delete history: it **archives**
+the originals in place (`UPDATE events SET aggregate_version = n`, keeping their
+`id`, `created`, and `global_position`) and **inserts brand-new synthetic events**
+for the compacted tail (new ids, new `global_position`, `aggregate_version = NULL`).
+
+This breaks both naive policy-feed reads:
+
+- Reading **all rows** by `global_position` walks the archived originals *and* the
+  synthetic copies of the post-checkpoint tail → some real events are processed
+  **twice**.
+- Reading only **live rows** (`aggregate_version IS NULL`) sees only the synthetic
+  snapshot → the lagging policy **skips** all pre-compaction history.
+
+## Decision
+
+Tag the synthetic rows inserted by step 6 of `compact` with a boolean marker (e.g.
+`compacted_snapshot = true`). The **policy feed reads the true log**:
+
+```sql
+WHERE compacted_snapshot = false ORDER BY global_position
+```
+
+— which includes archived originals (they are real) and excludes synthetic
+snapshots, *without* filtering on `aggregate_version`. Aggregate replay is
+unchanged and still reads the compacted fast path (`aggregate_version IS NULL`,
+including the synthetics). The same rows are thus read through two opposite lenses:
+aggregate replay wants the compacted snapshot; a Policy wants the true granular log.
+
+Policies and compaction stay **fully decoupled**: we deliberately do **not** gate
+compaction on the slowest policy's cursor, because a stuck or dead policy must
+never freeze write-model maintenance or grow the live stream unbounded.
+
+## Consequences
+
+- Archived originals become **load-bearing for policies** and cannot be pruned while
+  any policy (especially a `start_at: Beginning` one) might still need them.
+  Compaction already retains them, so this is no new storage cost — but "compaction
+  frees space" is now false for the policy log.
+- The lagging-policy-across-compaction scenarios (walk pre-compaction originals once,
+  never double-fire synthetics, continue past the checkpoint) are covered by
+  Docker-gated Postgres integration tests that document the intent.

--- a/persistence/src/cqrs.rs
+++ b/persistence/src/cqrs.rs
@@ -18,6 +18,11 @@ impl<ES: EventStore> Cqrs<ES> {
         }
     }
 
+    /// Shared handle to the underlying event store.
+    pub(crate) fn store(&self) -> &Arc<ES> {
+        &self.store
+    }
+
     /// Reconstruct an aggregate from its persisted event stream.
     ///
     /// - `aggregate_version`: choose which snapshot of the stream to load.  Use

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -102,7 +102,13 @@ impl PostgresEventStore {
         }
     }
 
-    fn add_filters(query_builder: &mut QueryBuilder<Postgres>, filter: StreamFilter) {
+    /// Accessor for the underlying connection pool (used by the policy runner to
+    /// read the event feed and policy cursors).
+    pub(crate) fn pool(&self) -> &Pool<Postgres> {
+        &self.pool
+    }
+
+    pub(crate) fn add_filters(query_builder: &mut QueryBuilder<Postgres>, filter: StreamFilter) {
         match filter {
             StreamFilter::All => {
                 query_builder.push(" 1 = 1");

--- a/persistence/src/lib.rs
+++ b/persistence/src/lib.rs
@@ -5,6 +5,8 @@ mod filters;
 mod infrastructure;
 mod inline_projection;
 mod persisted_event;
+mod policy;
+mod policy_runner;
 mod query;
 mod store;
 
@@ -15,6 +17,8 @@ pub use filters::StreamFilter;
 pub use infrastructure::{InMemoryEventStore, PostgresEventStore, PostgresInlineProjection};
 pub use inline_projection::InlineProjection;
 pub use persisted_event::PersistedEvent;
+pub use policy::{Dispatch, Policy};
+pub use policy_runner::{PolicyRunner, PolicyRunnerBuilder};
 pub use query::Query;
 pub use store::EventStore;
 
@@ -37,7 +41,8 @@ pub mod prelude {
 
     // Persistence types from this crate
     pub use super::{
-        AggregateVersion, Cqrs, EventStore, InMemoryEventStore, InlineProjection, PersistedEvent,
-        PostgresEventStore, PostgresInlineProjection, Query, StreamFilter,
+        AggregateVersion, Cqrs, Dispatch, EventStore, InMemoryEventStore, InlineProjection,
+        PersistedEvent, Policy, PolicyRunner, PolicyRunnerBuilder, PostgresEventStore,
+        PostgresInlineProjection, Query, StreamFilter,
     };
 }

--- a/persistence/src/policy.rs
+++ b/persistence/src/policy.rs
@@ -1,0 +1,122 @@
+//! Policies: checkpointed background subscribers that *react* to events by
+//! issuing commands.
+//!
+//! A [`Policy`] is a sibling of [`crate::Query`] / inline projections, not a
+//! kind of projection: it derives no read model. Given an event it returns a
+//! list of [`Dispatch`]es — commands the runner should execute against
+//! aggregates. This module is the **portable contract**: it carries no Postgres
+//! or tokio types, so the same `Policy` / `Dispatch` shapes can drive a future
+//! WASM runner. The server-side execution lives in the runner (native only).
+
+use std::any::{Any, TypeId};
+
+use replay::{Aggregate, Event};
+
+use crate::{PersistedEvent, StreamFilter};
+
+/// A command a [`Policy`] wants the runner to execute against an aggregate.
+///
+/// `Dispatch` is an *erased descriptor*: it remembers which aggregate type the
+/// command targets ([`TypeId`]) and carries the `(StreamId, Command)` pair as an
+/// opaque `Box<dyn Any + Send>` payload. The runner — which registered the
+/// concrete aggregate via `register_services::<A>` — downcasts the payload and
+/// runs it through `Cqrs::execute`. Crucially this struct names no Postgres or
+/// tokio types, so it stays WASM-ready.
+pub struct Dispatch {
+    pub(crate) target: TypeId,
+    pub(crate) aggregate_name: &'static str,
+    pub(crate) payload: Box<dyn Any + Send>,
+    pub(crate) expected_version: Option<i64>,
+}
+
+impl Dispatch {
+    /// Builds a dispatch targeting aggregate `A`, identified by `id`, carrying
+    /// `command`.
+    ///
+    /// ```rust,ignore
+    /// Dispatch::to::<BankAccount>(account_id, BankAccountCommand::Freeze)
+    /// ```
+    pub fn to<A>(id: A::StreamId, command: A::Command) -> Self
+    where
+        A: Aggregate + 'static,
+        A::StreamId: 'static,
+        A::Command: 'static,
+    {
+        Dispatch {
+            target: TypeId::of::<A>(),
+            aggregate_name: std::any::type_name::<A>(),
+            payload: Box::new((id, command)),
+            expected_version: None,
+        }
+    }
+
+    /// The [`TypeId`] of the aggregate this dispatch targets.
+    pub fn target(&self) -> TypeId {
+        self.target
+    }
+
+    /// The Rust type name of the target aggregate (diagnostics only).
+    pub fn aggregate_name(&self) -> &'static str {
+        self.aggregate_name
+    }
+}
+
+/// A checkpointed background subscriber that reacts to events with commands.
+///
+/// Implementors stay pure and store-agnostic: [`react`](Policy::react) takes an
+/// event and returns the commands to issue, with no I/O. The runner handles
+/// reading the feed, executing the returned [`Dispatch`]es, stamping causation
+/// metadata, and advancing the cursor.
+pub trait Policy: Send + Sync {
+    /// The event type this policy understands. Use `query_events!` to merge
+    /// events from several aggregates into one enum.
+    type Event: Event;
+
+    /// Stable identity used as the cursor key. Changing the Rust type must not
+    /// change this string, or the policy would lose its checkpoint.
+    fn name(&self) -> &str;
+
+    /// Narrows the feed to the streams this policy cares about. Defaults to the
+    /// whole log.
+    fn stream_filter(&self) -> StreamFilter {
+        StreamFilter::all()
+    }
+
+    /// Pure reaction: given an event, return the commands to dispatch.
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<Dispatch>;
+}
+
+/// Object-safe erasure of [`Policy`], mirroring `ErasedInlineProjection`.
+///
+/// The runner holds `Box<dyn ErasedPolicy>` and feeds it raw JSON events; the
+/// blanket impl deserializes into the concrete `Policy::Event` and skips events
+/// that don't belong to this policy (deserialize-or-skip routing).
+pub(crate) trait ErasedPolicy: Send + Sync {
+    fn name(&self) -> &str;
+
+    fn stream_filter(&self) -> StreamFilter;
+
+    fn react_erased(&self, raw: &PersistedEvent<serde_json::Value>) -> Vec<Dispatch>;
+}
+
+impl<P: Policy> ErasedPolicy for P {
+    fn name(&self) -> &str {
+        Policy::name(self)
+    }
+
+    fn stream_filter(&self) -> StreamFilter {
+        Policy::stream_filter(self)
+    }
+
+    fn react_erased(&self, raw: &PersistedEvent<serde_json::Value>) -> Vec<Dispatch> {
+        // Deserialize-or-skip: events whose payload isn't this policy's Event
+        // type simply produce no reaction.
+        match serde_json::from_value::<P::Event>(raw.data.clone()) {
+            Ok(event) => {
+                let typed = raw.clone().with_data(event);
+                self.react(&typed)
+            }
+            Err(_) => Vec::new(),
+        }
+    }
+}

--- a/persistence/src/policy.rs
+++ b/persistence/src/policy.rs
@@ -10,7 +10,7 @@
 
 use std::any::{Any, TypeId};
 
-use replay::{Aggregate, Event};
+use replay::{Aggregate, Event, Metadata};
 
 use crate::{PersistedEvent, StreamFilter};
 
@@ -27,6 +27,7 @@ pub struct Dispatch {
     pub(crate) aggregate_name: &'static str,
     pub(crate) payload: Box<dyn Any + Send>,
     pub(crate) expected_version: Option<i64>,
+    pub(crate) metadata: Option<Metadata>,
 }
 
 impl Dispatch {
@@ -47,7 +48,17 @@ impl Dispatch {
             aggregate_name: std::any::type_name::<A>(),
             payload: Box::new((id, command)),
             expected_version: None,
+            metadata: None,
         }
+    }
+
+    /// Attach user-defined metadata to this dispatch.
+    ///
+    /// The runner merges this metadata with causation metadata before executing
+    /// the command. Colliding top-level keys are rejected at runtime.
+    pub fn with_metadata(mut self, metadata: Metadata) -> Self {
+        self.metadata = Some(metadata);
+        self
     }
 
     /// The [`TypeId`] of the aggregate this dispatch targets.

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -14,7 +14,7 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 
 use futures::future::BoxFuture;
-use serde_json::Value;
+use serde_json::{Map, Value};
 use sqlx::{Pool, Postgres, QueryBuilder, Row};
 
 use replay::{Aggregate, Metadata};
@@ -233,7 +233,18 @@ impl PolicyRunner {
             .with_context("aggregate", dispatch.aggregate_name())
         })?;
 
-        let metadata = causation_metadata(policy_name, global_position, raw);
+        let aggregate_name = dispatch.aggregate_name();
+        let dispatch_metadata = dispatch.metadata.clone();
+
+        let metadata = merge_dispatch_metadata(
+            causation_metadata(policy_name, global_position, raw),
+            dispatch_metadata,
+        )
+        .map_err(|err| {
+            err.with_operation("policy_drain")
+                .with_context("policy", policy_name)
+                .with_context("aggregate", aggregate_name)
+        })?;
 
         executor
             .execute(
@@ -246,8 +257,8 @@ impl PolicyRunner {
     }
 
     async fn load_cursor(&self, name: &str) -> Result<i64, replay::Error> {
-        let position: Option<i64> =
-            sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = $1")
+        let position =
+            sqlx::query_scalar::<_, i64>("SELECT position FROM policy_cursors WHERE name = $1")
                 .bind(name)
                 .fetch_optional(&self.pool)
                 .await
@@ -287,4 +298,83 @@ fn causation_metadata(
             "global_position": global_position,
         }
     }))
+}
+
+fn merge_dispatch_metadata(
+    causation: Metadata,
+    dispatch: Option<Metadata>,
+) -> Result<Metadata, replay::Error> {
+    let Some(dispatch) = dispatch else {
+        return Ok(causation);
+    };
+
+    let Value::Object(mut merged) = causation.to_json() else {
+        return Err(replay::Error::internal(
+            "policy causation metadata must be a JSON object",
+        ));
+    };
+
+    let Value::Object(extra) = dispatch.to_json() else {
+        return Err(replay::Error::invalid_input(
+            "policy dispatch metadata must be a JSON object",
+        ));
+    };
+
+    merge_no_collisions(&mut merged, extra)?;
+    Ok(Metadata::new(Value::Object(merged)))
+}
+
+fn merge_no_collisions(
+    destination: &mut Map<String, Value>,
+    source: Map<String, Value>,
+) -> Result<(), replay::Error> {
+    for (key, value) in source {
+        if destination.contains_key(&key) {
+            return Err(replay::Error::invalid_input(
+                "policy dispatch metadata contains a key that collides with causation metadata",
+            )
+            .with_context("key", key));
+        }
+        destination.insert(key, value);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use replay::Metadata;
+    use serde_json::json;
+
+    use super::merge_dispatch_metadata;
+
+    #[test]
+    fn merges_dispatch_metadata_without_collisions() {
+        let causation = Metadata::new(json!({
+            "causation": { "policy": "p", "global_position": 1 }
+        }));
+        let dispatch = Metadata::new(json!({
+            "user_id": "u-1",
+            "related_aggregate_id": "urn:catalog:1"
+        }));
+
+        let merged = merge_dispatch_metadata(causation, Some(dispatch)).expect("must merge");
+        let value = merged.to_json();
+
+        assert_eq!(value["causation"]["policy"], "p");
+        assert_eq!(value["user_id"], "u-1");
+        assert_eq!(value["related_aggregate_id"], "urn:catalog:1");
+    }
+
+    #[test]
+    fn errors_on_metadata_key_collision() {
+        let causation = Metadata::new(json!({ "causation": { "policy": "p" } }));
+        let dispatch = Metadata::new(json!({ "causation": { "override": true } }));
+
+        let err = merge_dispatch_metadata(causation, Some(dispatch)).expect_err("must fail");
+
+        assert_eq!(err.kind(), replay::ErrorKind::InvalidInput);
+        assert!(err
+            .to_string()
+            .contains("policy dispatch metadata contains a key that collides"));
+    }
 }

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -1,0 +1,290 @@
+//! The native Policy runner.
+//!
+//! Where [`crate::policy`] is the portable *contract* (no Postgres/tokio types),
+//! this module is the server-side *runtime*: it reads the global event feed,
+//! routes events through registered [`Policy`]s, executes the [`Dispatch`]es they
+//! return through [`Cqrs`], stamps causation metadata, and advances each policy's
+//! persisted cursor.
+//!
+//! This is the #77 walking skeleton: a single, manual [`PolicyRunner::drain`].
+//! The background daemon, leadership election, batching, and NOTIFY wake-ups are
+//! later slices that build on this substrate.
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+
+use futures::future::BoxFuture;
+use serde_json::Value;
+use sqlx::{Pool, Postgres, QueryBuilder, Row};
+
+use replay::{Aggregate, Metadata};
+
+use crate::policy::{Dispatch, ErasedPolicy, Policy};
+use crate::{Cqrs, PersistedEvent, PostgresEventStore, StreamFilter};
+
+/// Erased, services-bound execution path for one aggregate type.
+///
+/// Registered via [`PolicyRunnerBuilder::register_services`], which captures the
+/// concrete aggregate `A` *and* its `Services`. At drain time the runner looks up
+/// the executor by the [`Dispatch`]'s [`TypeId`], hands over the opaque payload,
+/// and the executor downcasts it back to `(A::StreamId, A::Command)` and runs it
+/// through [`Cqrs::execute`].
+trait AggregateExecutor: Send + Sync {
+    fn execute<'a>(
+        &'a self,
+        cqrs: &'a Cqrs<PostgresEventStore>,
+        payload: Box<dyn Any + Send>,
+        metadata: Metadata,
+        expected_version: Option<i64>,
+    ) -> BoxFuture<'a, Result<(), replay::Error>>;
+}
+
+struct TypedExecutor<A: Aggregate> {
+    services: A::Services,
+}
+
+impl<A> AggregateExecutor for TypedExecutor<A>
+where
+    A: Aggregate + 'static,
+    A::StreamId: 'static,
+    A::Command: 'static,
+    A::Services: Send + Sync + 'static,
+{
+    fn execute<'a>(
+        &'a self,
+        cqrs: &'a Cqrs<PostgresEventStore>,
+        payload: Box<dyn Any + Send>,
+        metadata: Metadata,
+        expected_version: Option<i64>,
+    ) -> BoxFuture<'a, Result<(), replay::Error>> {
+        Box::pin(async move {
+            let (id, command) = *payload
+                .downcast::<(A::StreamId, A::Command)>()
+                .map_err(|_| {
+                    replay::Error::internal("policy dispatch payload type mismatch")
+                        .with_operation("policy_execute")
+                })?;
+
+            cqrs.execute::<A>(&id, metadata, command, &self.services, expected_version)
+                .await
+                .map(|_| ())
+                .map_err(|e| {
+                    replay::Error::internal(format!("policy command failed: {e}"))
+                        .with_operation("policy_execute")
+                })
+        })
+    }
+}
+
+/// Builds a [`PolicyRunner`] by registering aggregate services and policies.
+pub struct PolicyRunnerBuilder {
+    cqrs: Cqrs<PostgresEventStore>,
+    pool: Pool<Postgres>,
+    policies: Vec<Box<dyn ErasedPolicy>>,
+    executors: HashMap<TypeId, Box<dyn AggregateExecutor>>,
+}
+
+impl PolicyRunnerBuilder {
+    /// Register the `Services` for aggregate `A`, enabling policies to dispatch
+    /// commands to it. The runner owns the services and injects them when it
+    /// executes a [`Dispatch::to::<A>`].
+    pub fn register_services<A>(mut self, services: A::Services) -> Self
+    where
+        A: Aggregate + 'static,
+        A::StreamId: 'static,
+        A::Command: 'static,
+        A::Services: Send + Sync + 'static,
+    {
+        self.executors
+            .insert(TypeId::of::<A>(), Box::new(TypedExecutor::<A> { services }));
+        self
+    }
+
+    /// Register a policy. Its `name` becomes the stable cursor key.
+    pub fn register_policy<P>(mut self, policy: P) -> Self
+    where
+        P: Policy + 'static,
+    {
+        self.policies.push(Box::new(policy));
+        self
+    }
+
+    pub fn build(self) -> PolicyRunner {
+        PolicyRunner {
+            cqrs: self.cqrs,
+            pool: self.pool,
+            policies: self.policies,
+            executors: self.executors,
+        }
+    }
+}
+
+/// Native runner that drives registered policies against the event feed.
+pub struct PolicyRunner {
+    cqrs: Cqrs<PostgresEventStore>,
+    pool: Pool<Postgres>,
+    policies: Vec<Box<dyn ErasedPolicy>>,
+    executors: HashMap<TypeId, Box<dyn AggregateExecutor>>,
+}
+
+impl PolicyRunner {
+    /// Begin configuring a runner bound to `cqrs` (and its connection pool).
+    pub fn builder(cqrs: Cqrs<PostgresEventStore>) -> PolicyRunnerBuilder {
+        let pool = cqrs.store().pool().clone();
+        PolicyRunnerBuilder {
+            cqrs,
+            pool,
+            policies: Vec::new(),
+            executors: HashMap::new(),
+        }
+    }
+
+    /// Manually drain every registered policy once.
+    ///
+    /// For each policy: read the gap-free prefix of events past its cursor,
+    /// `react`, execute the returned dispatches through [`Cqrs`], and advance the
+    /// cursor — one event at a time, advancing only after that event's commands
+    /// have committed (at-least-once delivery; reactions must be idempotent).
+    ///
+    /// Returns the total number of dispatches executed across all policies.
+    pub async fn drain(&self) -> Result<usize, replay::Error> {
+        let mut total = 0;
+        for policy in &self.policies {
+            total += self.drain_policy(policy.as_ref()).await?;
+        }
+        Ok(total)
+    }
+
+    async fn drain_policy(&self, policy: &dyn ErasedPolicy) -> Result<usize, replay::Error> {
+        let name = policy.name().to_string();
+        let cursor = self.load_cursor(&name).await?;
+        let feed = self.read_feed(policy.stream_filter(), cursor).await?;
+
+        let mut executed = 0;
+        for (global_position, raw) in feed {
+            for dispatch in policy.react_erased(&raw) {
+                self.execute_dispatch(&name, global_position, &raw, dispatch)
+                    .await?;
+                executed += 1;
+            }
+            // Advance only after this event's commands have committed. A crash
+            // before this point re-delivers the event on the next drain.
+            self.save_cursor(&name, global_position).await?;
+        }
+
+        Ok(executed)
+    }
+
+    /// Read the contiguous, gap-free prefix of events with
+    /// `global_position > cursor` matching `filter`, in global order.
+    ///
+    /// BIGSERIAL positions are assigned at INSERT but become visible at COMMIT,
+    /// so a higher position can appear before a lower one fills in. Stopping at
+    /// the first gap guarantees we never skip an event that is still in flight.
+    async fn read_feed(
+        &self,
+        filter: StreamFilter,
+        cursor: i64,
+    ) -> Result<Vec<(i64, PersistedEvent<Value>)>, replay::Error> {
+        let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
+            "SELECT id, data, metadata, stream_id, type, version, created, aggregate_version, \
+             global_position FROM events WHERE global_position > ",
+        );
+        qb.push_bind(cursor);
+        qb.push(" AND ");
+        PostgresEventStore::add_filters(&mut qb, filter);
+        qb.push(" ORDER BY global_position ASC");
+
+        let rows = qb
+            .build()
+            .fetch_all(&self.pool)
+            .await
+            .map_err(crate::db_error)?;
+
+        let mut feed = Vec::with_capacity(rows.len());
+        let mut expected = cursor + 1;
+        for row in rows {
+            let global_position: i64 = row.get("global_position");
+            if global_position != expected {
+                // Gap: stop here and let the hole fill on a later drain.
+                break;
+            }
+            let event = PersistedEvent::<Value>::try_from(row)?;
+            feed.push((global_position, event));
+            expected += 1;
+        }
+
+        Ok(feed)
+    }
+
+    async fn execute_dispatch(
+        &self,
+        policy_name: &str,
+        global_position: i64,
+        raw: &PersistedEvent<Value>,
+        dispatch: Dispatch,
+    ) -> Result<(), replay::Error> {
+        let executor = self.executors.get(&dispatch.target()).ok_or_else(|| {
+            replay::Error::invalid_input(
+                "no services registered for the aggregate targeted by a policy dispatch",
+            )
+            .with_operation("policy_drain")
+            .with_context("policy", policy_name)
+            .with_context("aggregate", dispatch.aggregate_name())
+        })?;
+
+        let metadata = causation_metadata(policy_name, global_position, raw);
+
+        executor
+            .execute(
+                &self.cqrs,
+                dispatch.payload,
+                metadata,
+                dispatch.expected_version,
+            )
+            .await
+    }
+
+    async fn load_cursor(&self, name: &str) -> Result<i64, replay::Error> {
+        let position: Option<i64> =
+            sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = $1")
+                .bind(name)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(crate::db_error)?;
+        Ok(position.unwrap_or(0))
+    }
+
+    async fn save_cursor(&self, name: &str, position: i64) -> Result<(), replay::Error> {
+        sqlx::query(
+            "INSERT INTO policy_cursors (name, position, updated_at) VALUES ($1, $2, now()) \
+             ON CONFLICT (name) DO UPDATE SET position = EXCLUDED.position, updated_at = now()",
+        )
+        .bind(name)
+        .bind(position)
+        .execute(&self.pool)
+        .await
+        .map_err(crate::db_error)?;
+        Ok(())
+    }
+}
+
+/// Causation metadata stamped on every command a policy issues.
+///
+/// Records which policy reacted and which event triggered it. This is the seed
+/// of the causation chain that later slices use for idempotency (#80) and
+/// loop-depth limiting (#83).
+fn causation_metadata(
+    policy_name: &str,
+    global_position: i64,
+    raw: &PersistedEvent<Value>,
+) -> Metadata {
+    Metadata::new(serde_json::json!({
+        "causation": {
+            "policy": policy_name,
+            "event_id": raw.id.to_string(),
+            "stream_id": raw.stream_id.to_string(),
+            "global_position": global_position,
+        }
+    }))
+}

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -1405,7 +1405,11 @@ impl replay_persistence::Policy for WithdrawFeePolicy {
                         effective_on: *operation_date,
                         amount: self.fee,
                     },
-                )]
+                )
+                .with_metadata(replay::Metadata::new(serde_json::json!({
+                    "user_id": "policy-runner",
+                    "related_aggregate_id": event.stream_id.to_string(),
+                })))]
             }
             _ => Vec::new(),
         }
@@ -1505,6 +1509,27 @@ async fn withdraw_fee_policy_drain_postgres_test() {
     // The reaction's command landed: balance is 100 - 5 = 95.
     let account_state = cqrs.fetch_aggregate::<BankAccount>(&account).await.unwrap();
     assert_eq!(account_state.balance, 95.0);
+
+    // The resulting command metadata includes both causation and policy-provided
+    // context fields.
+    let withdrawal_meta: serde_json::Value = sqlx::query_scalar(
+        "SELECT metadata FROM events WHERE stream_id = $1 AND type = $2 ORDER BY version DESC LIMIT 1",
+    )
+    .bind(Into::<Urn>::into(account.clone()).to_string())
+    .bind("Withdrawn")
+    .fetch_one(&pg_pool)
+    .await
+    .expect("withdrawal event must exist");
+
+    assert_eq!(withdrawal_meta["user_id"], "policy-runner");
+    assert_eq!(
+        withdrawal_meta["related_aggregate_id"],
+        Into::<Urn>::into(account.clone()).to_string()
+    );
+    assert_eq!(
+        withdrawal_meta["causation"]["policy"],
+        "withdraw_fee_policy"
+    );
 
     // The cursor advanced past the triggering event (global_position 1).
     let cursor: i64 = sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = $1")

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -1377,3 +1377,153 @@ async fn global_position_live_query_and_inline_projection_agree_postgres_test() 
     assert_eq!(live.position().name, inline_name);
     assert_eq!(live.position().total_balance, inline_balance);
 }
+
+// ── Policies: checkpointed background reactions (issue #77) ───────────────────
+
+/// A toy policy: whenever a deposit lands, charge a flat fee by issuing a
+/// `Withdraw` command back to the same account. Because `Withdrawn` is not a
+/// `Deposited`, the reaction does not feed itself — no loop.
+struct WithdrawFeePolicy {
+    fee: f64,
+}
+
+impl replay_persistence::Policy for WithdrawFeePolicy {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "withdraw_fee_policy"
+    }
+
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        match &event.data {
+            BankAccountEvent::Deposited { operation_date, .. } => {
+                let account = BankAccountUrn::try_from(event.stream_id.clone())
+                    .expect("deposit events live on bank-account streams");
+                vec![replay_persistence::Dispatch::to::<BankAccount>(
+                    account,
+                    BankAccountCommand::Withdraw {
+                        effective_on: *operation_date,
+                        amount: self.fee,
+                    },
+                )]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// Pure `react` unit test — no database. Asserts the policy returns exactly one
+/// dispatch, targeting the `BankAccount` aggregate, on a deposit, and nothing on
+/// other events.
+#[test]
+fn withdraw_fee_policy_react_is_pure() {
+    use std::any::TypeId;
+
+    let policy = WithdrawFeePolicy { fee: 5.0 };
+    let stream_id: Urn = BankAccountUrn::new("pure-react-1").unwrap().into();
+
+    let deposit = PersistedEvent {
+        id: uuid::Uuid::new_v4(),
+        data: BankAccountEvent::Deposited {
+            operation_date: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        stream_id: stream_id.clone(),
+        r#type: "Deposited".to_string(),
+        version: 1,
+        created: chrono::Utc::now(),
+        metadata: replay::Metadata::default(),
+        aggregate_version: None,
+    };
+
+    let dispatches = replay_persistence::Policy::react(&policy, &deposit);
+    assert_eq!(dispatches.len(), 1);
+    assert_eq!(dispatches[0].target(), TypeId::of::<BankAccount>());
+
+    let withdrawal = PersistedEvent {
+        data: BankAccountEvent::Withdrawn {
+            operation_date: chrono::NaiveDate::from_ymd_opt(2025, 1, 2).unwrap(),
+            amount: 5.0,
+        },
+        r#type: "Withdrawn".to_string(),
+        ..deposit
+    };
+
+    assert!(replay_persistence::Policy::react(&policy, &withdrawal).is_empty());
+}
+
+/// End-to-end walking skeleton: append a deposit, drain the policy once, and
+/// assert the reaction's `Withdrawn` event landed (balance dropped by the fee)
+/// and the policy cursor advanced past the triggering event.
+#[tokio::test]
+async fn withdraw_fee_policy_drain_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+
+    let account = BankAccountUrn::new("policy-drain-1").unwrap();
+
+    // Append the triggering event.
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(WithdrawFeePolicy { fee: 5.0 })
+        .build();
+
+    let executed = runner.drain().await.expect("drain must succeed");
+    assert_eq!(
+        executed, 1,
+        "the deposit must trigger exactly one withdrawal"
+    );
+
+    // The reaction's command landed: balance is 100 - 5 = 95.
+    let account_state = cqrs.fetch_aggregate::<BankAccount>(&account).await.unwrap();
+    assert_eq!(account_state.balance, 95.0);
+
+    // The cursor advanced past the triggering event (global_position 1).
+    let cursor: i64 = sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = $1")
+        .bind("withdraw_fee_policy")
+        .fetch_one(&pg_pool)
+        .await
+        .expect("cursor row must exist after drain");
+    assert_eq!(cursor, 1);
+
+    // A second drain re-scans only the new `Withdrawn` event, which the policy
+    // ignores, so no further commands are issued and the cursor moves to 2.
+    let executed_again = runner.drain().await.expect("second drain must succeed");
+    assert_eq!(executed_again, 0);
+
+    let cursor_after: i64 =
+        sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = $1")
+            .bind("withdraw_fee_policy")
+            .fetch_one(&pg_pool)
+            .await
+            .expect("cursor row must exist after second drain");
+    assert_eq!(cursor_after, 2);
+}

--- a/persistence/tests/migrations/0007_global_position.sql
+++ b/persistence/tests/migrations/0007_global_position.sql
@@ -1,0 +1,18 @@
+-- Global position: a single monotonic, store-wide ordering for events.
+--
+-- Per-stream `version` orders events *within* one aggregate stream, but Policies
+-- need a *total* order over the whole log to checkpoint against. We add a
+-- `BIGSERIAL` so every appended event gets a globally increasing position, and
+-- index it so the policy feed can scan `WHERE global_position > $cursor ORDER BY
+-- global_position` cheaply.
+--
+-- NOTE on visibility: BIGSERIAL values are assigned at INSERT time but become
+-- visible at COMMIT time, so under concurrent appends a higher position can
+-- commit before a lower one. The policy reader compensates with a high-water-mark
+-- scan (it only advances across a contiguous, gap-free prefix), so an
+-- assigned-but-not-yet-committed position is never skipped.
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS global_position BIGSERIAL;
+
+CREATE INDEX IF NOT EXISTS idx_events_global_position
+    ON events (global_position);

--- a/persistence/tests/migrations/0008_policy_cursors.sql
+++ b/persistence/tests/migrations/0008_policy_cursors.sql
@@ -1,0 +1,15 @@
+-- Per-policy catch-up cursor.
+--
+-- Each Policy is a checkpointed background subscriber over the event log. Unlike
+-- inline projections (which run inside the append transaction and are never
+-- behind, so store no position), a Policy stores the `global_position` of the
+-- last event whose command it has durably processed. On restart it resumes from
+-- here — a code/version change never rewinds it.
+--
+-- `name` is the Policy's stable identity (NOT its Rust type name). `position` is
+-- the last processed `global_position` (0 means "nothing processed yet").
+CREATE TABLE IF NOT EXISTS policy_cursors (
+    name        TEXT                        NOT NULL    PRIMARY KEY,
+    position    BIGINT                      NOT NULL    DEFAULT 0,
+    updated_at  TIMESTAMP WITH TIME ZONE    NOT NULL    DEFAULT (now())
+);


### PR DESCRIPTION
## Summary

Walking skeleton for **Policies** (issue #77) — a checkpointed background subscriber that reacts to events by issuing commands. A Policy is a sibling of projections, not a kind of projection: it derives no read model; its output is a command plus side effects.

## What's in this slice

**Portable contract** (`persistence/src/policy.rs`, no Postgres/tokio types — WASM-ready):
- `Policy` trait: `name` (stable cursor key), `stream_filter`, pure `react(&PersistedEvent) -> Vec<Dispatch>`.
- `Dispatch::to::<A>(id, command)` — an erased descriptor carrying `TypeId::of::<A>()` plus an opaque `(StreamId, Command)` payload.

**Native runner** (`persistence/src/policy_runner.rs`):
- `register_services::<A>(services)` binds an aggregate's `Services`; `register_policy(..)` registers a policy.
- `PolicyRunner::drain()` reads a gap-free `global_position` prefix past each policy's cursor (high-water-mark), runs `react`, executes dispatches via `Cqrs`, stamps causation metadata, and advances the cursor only past committed commands (at-least-once; reactions must be idempotent).

**Schema** (test fixtures):
- `0007_global_position.sql`: `BIGSERIAL global_position` + index.
- `0008_policy_cursors.sql`: per-policy cursor table keyed by stable `name`.

**Docs**: ADR-0003 (policies as checkpointed background subscribers), ADR-0004 (compaction synthetic-event marker for the policy feed); CONTEXT.md glossary terms (`Policy`, `Causation`); ADR-0001 checkpoint-scope patch.

## Tests

- `withdraw_fee_policy_react_is_pure` — pure `react`, no database.
- `withdraw_fee_policy_drain_postgres_test` — append → drain → reaction's event landed and cursor advanced.

All 19 persistence tests pass; `cargo fmt --check` and `cargo clippy -D warnings` clean.

Closes #77