### PR TITLE
feat(persistence): add policy StartAt bootstrap (#78)

### DIFF
--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -678,9 +678,13 @@ impl<D: DeserializeOwned> TryFrom<PgRow> for PersistedEvent<D> {
                 .with_context("stored_json", data_raw.clone())
         })?;
 
-        // should not panic as we only store urns
         let stream_id_string: String = value.get("stream_id");
-        let stream_id: Urn = Urn::try_from(stream_id_string).unwrap();
+        let stream_id: Urn = Urn::try_from(stream_id_string.clone()).map_err(|e| {
+            replay::Error::internal("failed to parse persisted stream_id as URN")
+                .with_operation("postgres_row_to_persisted_event")
+                .with_context("stream_id", stream_id_string)
+                .with_source(e)
+        })?;
         let r#type: String = value.get("type");
         let version: i64 = value.get("version");
         let created: chrono::DateTime<Utc> = value.get("created");

--- a/persistence/src/lib.rs
+++ b/persistence/src/lib.rs
@@ -17,7 +17,7 @@ pub use filters::StreamFilter;
 pub use infrastructure::{InMemoryEventStore, PostgresEventStore, PostgresInlineProjection};
 pub use inline_projection::InlineProjection;
 pub use persisted_event::PersistedEvent;
-pub use policy::{Dispatch, Policy};
+pub use policy::{Dispatch, Policy, StartAt};
 pub use policy_runner::{PolicyRunner, PolicyRunnerBuilder};
 pub use query::Query;
 pub use store::EventStore;
@@ -43,6 +43,6 @@ pub mod prelude {
     pub use super::{
         AggregateVersion, Cqrs, Dispatch, EventStore, InMemoryEventStore, InlineProjection,
         PersistedEvent, Policy, PolicyRunner, PolicyRunnerBuilder, PostgresEventStore,
-        PostgresInlineProjection, Query, StreamFilter,
+        PostgresInlineProjection, Query, StartAt, StreamFilter,
     };
 }

--- a/persistence/src/policy.rs
+++ b/persistence/src/policy.rs
@@ -14,6 +14,17 @@ use replay::{Aggregate, Event, Metadata};
 
 use crate::{PersistedEvent, StreamFilter};
 
+/// Cursor initialization behavior used on first policy registration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StartAt {
+    /// Start from the current global head, so only newly appended events are
+    /// processed.
+    #[default]
+    Now,
+    /// Start from position 0 and process full history once.
+    Beginning,
+}
+
 /// A command a [`Policy`] wants the runner to execute against an aggregate.
 ///
 /// `Dispatch` is an *erased descriptor*: it remembers which aggregate type the
@@ -93,6 +104,14 @@ pub trait Policy: Send + Sync {
         StreamFilter::all()
     }
 
+    /// Cursor bootstrap strategy used only when this policy name is first seen.
+    ///
+    /// Defaults to [`StartAt::Now`], the safe mode that avoids retroactively
+    /// firing commands across existing history.
+    fn start_at(&self) -> StartAt {
+        StartAt::Now
+    }
+
     /// Pure reaction: given an event, return the commands to dispatch.
     fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<Dispatch>;
 }
@@ -107,6 +126,8 @@ pub(crate) trait ErasedPolicy: Send + Sync {
 
     fn stream_filter(&self) -> StreamFilter;
 
+    fn start_at(&self) -> StartAt;
+
     fn react_erased(&self, raw: &PersistedEvent<serde_json::Value>) -> Vec<Dispatch>;
 }
 
@@ -117,6 +138,10 @@ impl<P: Policy> ErasedPolicy for P {
 
     fn stream_filter(&self) -> StreamFilter {
         Policy::stream_filter(self)
+    }
+
+    fn start_at(&self) -> StartAt {
+        Policy::start_at(self)
     }
 
     fn react_erased(&self, raw: &PersistedEvent<serde_json::Value>) -> Vec<Dispatch> {

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -298,7 +298,10 @@ impl PolicyRunner {
                         .fetch_one(&self.pool)
                         .await
                         .map_err(crate::db_error)?;
-                Ok(head.unwrap_or(0))
+                Ok(match head {
+                    Some(position) => position,
+                    None => 0,
+                })
             }
         }
     }

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -19,7 +19,7 @@ use sqlx::{Pool, Postgres, QueryBuilder, Row};
 
 use replay::{Aggregate, Metadata};
 
-use crate::policy::{Dispatch, ErasedPolicy, Policy};
+use crate::policy::{Dispatch, ErasedPolicy, Policy, StartAt};
 use crate::{Cqrs, PersistedEvent, PostgresEventStore, StreamFilter};
 
 /// Erased, services-bound execution path for one aggregate type.
@@ -157,7 +157,7 @@ impl PolicyRunner {
 
     async fn drain_policy(&self, policy: &dyn ErasedPolicy) -> Result<usize, replay::Error> {
         let name = policy.name().to_string();
-        let cursor = self.load_cursor(&name).await?;
+        let cursor = self.load_cursor(&name, policy.start_at()).await?;
         let feed = self.read_feed(policy.stream_filter(), cursor).await?;
 
         let mut executed = 0;
@@ -256,14 +256,51 @@ impl PolicyRunner {
             .await
     }
 
-    async fn load_cursor(&self, name: &str) -> Result<i64, replay::Error> {
+    async fn load_cursor(&self, name: &str, start_at: StartAt) -> Result<i64, replay::Error> {
         let position =
             sqlx::query_scalar::<_, i64>("SELECT position FROM policy_cursors WHERE name = $1")
                 .bind(name)
                 .fetch_optional(&self.pool)
                 .await
                 .map_err(crate::db_error)?;
-        Ok(position.unwrap_or(0))
+
+        if let Some(position) = position {
+            return Ok(position);
+        }
+
+        let bootstrap_position = self.bootstrap_position(start_at).await?;
+        sqlx::query(
+            "INSERT INTO policy_cursors (name, position, updated_at) VALUES ($1, $2, now()) \
+             ON CONFLICT (name) DO NOTHING",
+        )
+        .bind(name)
+        .bind(bootstrap_position)
+        .execute(&self.pool)
+        .await
+        .map_err(crate::db_error)?;
+
+        let persisted =
+            sqlx::query_scalar::<_, i64>("SELECT position FROM policy_cursors WHERE name = $1")
+                .bind(name)
+                .fetch_one(&self.pool)
+                .await
+                .map_err(crate::db_error)?;
+
+        Ok(persisted)
+    }
+
+    async fn bootstrap_position(&self, start_at: StartAt) -> Result<i64, replay::Error> {
+        match start_at {
+            StartAt::Beginning => Ok(0),
+            StartAt::Now => {
+                let head =
+                    sqlx::query_scalar::<_, Option<i64>>("SELECT MAX(global_position) FROM events")
+                        .fetch_one(&self.pool)
+                        .await
+                        .map_err(crate::db_error)?;
+                Ok(head.unwrap_or(0))
+            }
+        }
     }
 
     async fn save_cursor(&self, name: &str, position: i64) -> Result<(), replay::Error> {

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -1387,11 +1387,23 @@ struct WithdrawFeePolicy {
     fee: f64,
 }
 
+struct WithdrawFeePolicyStartAtNow {
+    fee: f64,
+}
+
+struct WithdrawFeePolicyStartAtBeginning {
+    fee: f64,
+}
+
 impl replay_persistence::Policy for WithdrawFeePolicy {
     type Event = BankAccountEvent;
 
     fn name(&self) -> &str {
         "withdraw_fee_policy"
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Beginning
     }
 
     fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
@@ -1410,6 +1422,64 @@ impl replay_persistence::Policy for WithdrawFeePolicy {
                     "user_id": "policy-runner",
                     "related_aggregate_id": event.stream_id.to_string(),
                 })))]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+impl replay_persistence::Policy for WithdrawFeePolicyStartAtNow {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "withdraw_fee_policy_start_at_now"
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Now
+    }
+
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        match &event.data {
+            BankAccountEvent::Deposited { operation_date, .. } => {
+                let account = BankAccountUrn::try_from(event.stream_id.clone())
+                    .expect("deposit events live on bank-account streams");
+                vec![replay_persistence::Dispatch::to::<BankAccount>(
+                    account,
+                    BankAccountCommand::Withdraw {
+                        effective_on: *operation_date,
+                        amount: self.fee,
+                    },
+                )]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+impl replay_persistence::Policy for WithdrawFeePolicyStartAtBeginning {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "withdraw_fee_policy_start_at_beginning"
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Beginning
+    }
+
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        match &event.data {
+            BankAccountEvent::Deposited { operation_date, .. } => {
+                let account = BankAccountUrn::try_from(event.stream_id.clone())
+                    .expect("deposit events live on bank-account streams");
+                vec![replay_persistence::Dispatch::to::<BankAccount>(
+                    account,
+                    BankAccountCommand::Withdraw {
+                        effective_on: *operation_date,
+                        amount: self.fee,
+                    },
+                )]
             }
             _ => Vec::new(),
         }
@@ -1551,4 +1621,245 @@ async fn withdraw_fee_policy_drain_postgres_test() {
             .await
             .expect("cursor row must exist after second drain");
     assert_eq!(cursor_after, 2);
+}
+
+#[tokio::test]
+async fn policy_start_at_now_ignores_prior_history_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("policy-start-now-1").unwrap();
+
+    // Pre-existing history before policy registration.
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(WithdrawFeePolicyStartAtNow { fee: 5.0 })
+        .build();
+
+    // First drain should not backfill pre-existing event.
+    let executed = runner.drain().await.expect("drain must succeed");
+    assert_eq!(executed, 0);
+
+    // New events appended after registration should be processed.
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 2).unwrap(),
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let executed_after = runner.drain().await.expect("second drain must succeed");
+    assert_eq!(executed_after, 1);
+}
+
+#[tokio::test]
+async fn policy_start_at_beginning_backfills_history_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("policy-start-beginning-1").unwrap();
+
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 2).unwrap(),
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(WithdrawFeePolicyStartAtBeginning { fee: 5.0 })
+        .build();
+
+    let executed = runner.drain().await.expect("drain must succeed");
+    assert_eq!(executed, 2);
+}
+
+#[tokio::test]
+async fn policy_code_change_never_rewinds_cursor_postgres_test() {
+    struct WithdrawFeePolicyNoRewindV1;
+    struct WithdrawFeePolicyNoRewindV2;
+
+    impl replay_persistence::Policy for WithdrawFeePolicyNoRewindV1 {
+        type Event = BankAccountEvent;
+
+        fn name(&self) -> &str {
+            "withdraw_fee_policy_no_rewind"
+        }
+
+        fn start_at(&self) -> replay_persistence::StartAt {
+            replay_persistence::StartAt::Now
+        }
+
+        fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+            match &event.data {
+                BankAccountEvent::Deposited { operation_date, .. } => {
+                    let account = BankAccountUrn::try_from(event.stream_id.clone())
+                        .expect("deposit events live on bank-account streams");
+                    vec![replay_persistence::Dispatch::to::<BankAccount>(
+                        account,
+                        BankAccountCommand::Withdraw {
+                            effective_on: *operation_date,
+                            amount: 5.0,
+                        },
+                    )]
+                }
+                _ => Vec::new(),
+            }
+        }
+    }
+
+    impl replay_persistence::Policy for WithdrawFeePolicyNoRewindV2 {
+        type Event = BankAccountEvent;
+
+        fn name(&self) -> &str {
+            "withdraw_fee_policy_no_rewind"
+        }
+
+        // Simulate a code change that attempts to switch bootstrap mode.
+        fn start_at(&self) -> replay_persistence::StartAt {
+            replay_persistence::StartAt::Beginning
+        }
+
+        fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+            match &event.data {
+                BankAccountEvent::Deposited { operation_date, .. } => {
+                    let account = BankAccountUrn::try_from(event.stream_id.clone())
+                        .expect("deposit events live on bank-account streams");
+                    vec![replay_persistence::Dispatch::to::<BankAccount>(
+                        account,
+                        BankAccountCommand::Withdraw {
+                            effective_on: *operation_date,
+                            amount: 7.0,
+                        },
+                    )]
+                }
+                _ => Vec::new(),
+            }
+        }
+    }
+
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("policy-no-rewind-1").unwrap();
+
+    // Pre-existing event before first policy registration.
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let runner_v1 = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(WithdrawFeePolicyNoRewindV1)
+        .build();
+
+    // First run bootstraps at Now, so no backfill.
+    assert_eq!(runner_v1.drain().await.unwrap(), 0);
+
+    // Append a new event that should be processed once.
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 2).unwrap(),
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Simulate redeploy/code change with same policy name but different start_at.
+    let runner_v2 = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(WithdrawFeePolicyNoRewindV2)
+        .build();
+
+    // Must process only the new event; the original pre-registration event
+    // must not be replayed.
+    assert_eq!(runner_v2.drain().await.unwrap(), 1);
 }


### PR DESCRIPTION
## Summary

Implements issue #78 by adding explicit policy bootstrap semantics with a safe default:

- Adds `StartAt` to the policy contract with `Now` as default and `Beginning` as opt-in.
- Persists first-registration cursor bootstrap in `policy_cursors`:
  - `StartAt::Now` records current global head.
  - `StartAt::Beginning` records `0`.
- Ensures policy code/config changes never rewind: once a cursor row exists for a policy `name`, it is always resumed.

## Changes

- `persistence/src/policy.rs`
  - Added `StartAt` enum.
  - Added `Policy::start_at()` defaulting to `StartAt::Now`.
  - Threaded `start_at` through `ErasedPolicy`.

- `persistence/src/policy_runner.rs`
  - `load_cursor` now bootstraps/persists first cursor based on `start_at`.
  - Added `bootstrap_position` helper (`MAX(global_position)` for `Now`, `0` for `Beginning`).
  - Uses `INSERT ... ON CONFLICT DO NOTHING` and re-read to be race-safe.

- `persistence/src/lib.rs`
  - Re-exported `StartAt` in crate root and prelude.

- `persistence/tests/integration_tests.rs`
  - Added postgres tests:
    - `policy_start_at_now_ignores_prior_history_postgres_test`
    - `policy_start_at_beginning_backfills_history_postgres_test`
    - `policy_code_change_never_rewinds_cursor_postgres_test`
  - Updated existing `WithdrawFeePolicy` test policy to explicitly use `StartAt::Beginning` to preserve the walking-skeleton behavior under the new default.

## Validation

- `cargo fmt`
- `cargo test -p es-replay-persistence policy -- --nocapture`

Closes #78
