### PR TITLE
feat(persistence): compaction true-log policy feed (#81)

### DIFF
--- a/persistence/examples/global_position.rs
+++ b/persistence/examples/global_position.rs
@@ -194,6 +194,91 @@ impl Compactable for BankAccount {
     }
 }
 
+// ── Policy idempotency recipe (causation guard) ─────────────────────────────
+
+// This aggregate is a copy-pasteable recipe for policy targets under
+// at-least-once delivery:
+// - command carries `causation_event_id` from the triggering event
+// - state tracks applied causation ids
+// - duplicate causation id => no-op (returns no events)
+define_aggregate! {
+    PolicyFeeLedger {
+        namespace: "policy-fee-ledger",
+        state: {
+            balance: f64,
+            applied_causation_ids: HashSet<uuid::Uuid>,
+        },
+        commands: {
+            Credit { amount: f64 },
+            ChargeFee {
+                amount: f64,
+                causation_event_id: uuid::Uuid,
+            },
+        },
+        events: {
+            Credited { amount: f64 },
+            FeeCharged {
+                amount: f64,
+                causation_event_id: uuid::Uuid,
+            },
+        }
+    }
+}
+
+impl EventStream for PolicyFeeLedger {
+    type Event = PolicyFeeLedgerEvent;
+
+    fn stream_type() -> String {
+        "PolicyFeeLedger".to_string()
+    }
+
+    fn apply(&mut self, event: Self::Event) {
+        match event {
+            PolicyFeeLedgerEvent::Credited { amount } => self.balance += amount,
+            PolicyFeeLedgerEvent::FeeCharged {
+                amount,
+                causation_event_id,
+            } => {
+                self.applied_causation_ids.insert(causation_event_id);
+                self.balance -= amount;
+            }
+        }
+    }
+}
+
+impl Aggregate for PolicyFeeLedger {
+    type Command = PolicyFeeLedgerCommand;
+    type Error = replay::Error;
+    type Services = ();
+
+    async fn handle(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> replay::Result<Vec<Self::Event>> {
+        match command {
+            PolicyFeeLedgerCommand::Credit { amount } => {
+                Ok(vec![PolicyFeeLedgerEvent::Credited { amount }])
+            }
+            PolicyFeeLedgerCommand::ChargeFee {
+                amount,
+                causation_event_id,
+            } => {
+                if self.applied_causation_ids.contains(&causation_event_id) {
+                    // Duplicate delivery for the same causation identity:
+                    // absorb as no-op.
+                    return Ok(Vec::new());
+                }
+
+                Ok(vec![PolicyFeeLedgerEvent::FeeCharged {
+                    amount,
+                    causation_event_id,
+                }])
+            }
+        }
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Cross-aggregate read model: a user's global position
 // ─────────────────────────────────────────────────────────────────────────────

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -618,6 +618,8 @@ impl EventStore for PostgresEventStore {
             .map_err(crate::db_error)?;
 
         // 6. Insert compacted events as the new current stream (aggregate_version = NULL).
+        //    These synthetic rows are marked compacted_snapshot = TRUE so the Policy feed
+        //    can skip them; the archived originals (above) carry the true history.
         let stream_type = A::stream_type();
         let meta_json = metadata.to_json();
         for (seq, event) in compacted.iter().enumerate() {
@@ -626,8 +628,8 @@ impl EventStore for PostgresEventStore {
             let version = (seq as i64) + 1;
 
             sqlx::query(
-                "INSERT INTO events (id, data, metadata, stream_id, type, version, aggregate_version)
-                 VALUES ($1, $2, $3, $4, $5, $6, NULL)",
+                "INSERT INTO events (id, data, metadata, stream_id, type, version, aggregate_version, compacted_snapshot)
+                 VALUES ($1, $2, $3, $4, $5, $6, NULL, TRUE)",
             )
             .bind(Uuid::new_v4())
             .bind(&data)

--- a/persistence/src/policy.rs
+++ b/persistence/src/policy.rs
@@ -85,8 +85,13 @@ impl Dispatch {
 
 /// A checkpointed background subscriber that reacts to events with commands.
 ///
-/// Implementors stay pure and store-agnostic: [`react`](Policy::react) takes an
-/// event and returns the commands to issue, with no I/O. The runner handles
+/// Delivery is **at-least-once**. A crash after command commit but before cursor
+/// save can re-deliver the same triggering event. Correctness therefore depends
+/// on idempotent command handling in the target aggregate, keyed by causation
+/// identity (the triggering event id), not by command-value equality.
+///
+/// Implementors stay pure and store-agnostic: [`react`](Policy::react) takes
+/// an event and returns the commands to issue, with no I/O. The runner handles
 /// reading the feed, executing the returned [`Dispatch`]es, stamping causation
 /// metadata, and advancing the cursor.
 pub trait Policy: Send + Sync {
@@ -113,6 +118,9 @@ pub trait Policy: Send + Sync {
     }
 
     /// Pure reaction: given an event, return the commands to dispatch.
+    ///
+    /// Invariant: because delivery is at-least-once, target aggregate command
+    /// handlers must absorb duplicate causation ids as no-ops.
     fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<Dispatch>;
 }
 

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -256,13 +256,17 @@ async fn drain_policy_once(
     let feed = read_feed(pool, policy.stream_filter(), *cursor).await?;
 
     let mut executed = 0;
-    for (global_position, raw) in feed {
-        for dispatch in policy.react_erased(&raw) {
-            execute_dispatch(cqrs, executors, &name, global_position, &raw, dispatch).await?;
-            executed += 1;
+    for (global_position, maybe_raw) in feed {
+        if let Some(raw) = maybe_raw {
+            // Real event: deliver to the policy and execute all returned dispatches.
+            for dispatch in policy.react_erased(&raw) {
+                execute_dispatch(cqrs, executors, &name, global_position, &raw, dispatch).await?;
+                executed += 1;
+            }
         }
-        // Advance only after this event's commands have committed. A crash
-        // before this point re-delivers the event on the next drain.
+        // Advance cursor regardless of whether the row was a real event or a synthetic
+        // compaction snapshot.  Synthetics must still move the cursor forward so the
+        // next poll does not re-process positions the runner has already seen.
         save_cursor(pool, &name, global_position).await?;
         *cursor = global_position;
     }
@@ -276,14 +280,18 @@ async fn drain_policy_once(
 /// BIGSERIAL positions are assigned at INSERT but become visible at COMMIT,
 /// so a higher position can appear before a lower one fills in. Stopping at
 /// the first gap guarantees we never skip an event that is still in flight.
+///
+/// Each entry is `(global_position, maybe_event)`.  When `maybe_event` is
+/// `None` the row is a synthetic compaction snapshot (`compacted_snapshot =
+/// TRUE`): the cursor must still advance past it, but no reaction is fired.
 async fn read_feed(
     pool: &Pool<Postgres>,
     filter: StreamFilter,
     cursor: i64,
-) -> Result<Vec<(i64, PersistedEvent<Value>)>, replay::Error> {
+) -> Result<Vec<(i64, Option<PersistedEvent<Value>>)>, replay::Error> {
     let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
         "SELECT id, data, metadata, stream_id, type, version, created, aggregate_version, \
-         global_position FROM events WHERE global_position > ",
+         global_position, compacted_snapshot FROM events WHERE global_position > ",
     );
     qb.push_bind(cursor);
     qb.push(" AND ");
@@ -300,9 +308,16 @@ async fn read_feed(
             // Gap: stop here and let the hole fill on a later poll.
             break;
         }
-        let event = PersistedEvent::<Value>::try_from(row)?;
-        feed.push((global_position, event));
         expected += 1;
+
+        let is_snapshot: bool = row.get("compacted_snapshot");
+        if is_snapshot {
+            // Synthetic row: advance the cursor past it, but deliver nothing.
+            feed.push((global_position, None));
+        } else {
+            let event = PersistedEvent::<Value>::try_from(row)?;
+            feed.push((global_position, Some(event)));
+        }
     }
 
     Ok(feed)

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -135,6 +135,85 @@ impl Compactable for BankAccount {
     }
 }
 
+define_aggregate! {
+    IdempotentFeeAccount {
+        namespace: "idempotent-fee-account",
+        state: {
+            balance: f64,
+            applied_causation_ids: std::collections::HashSet<uuid::Uuid>,
+        },
+        commands: {
+            Open { balance: f64 },
+            ChargeFee {
+                amount: f64,
+                causation_event_id: uuid::Uuid,
+            },
+        },
+        events: {
+            Opened { balance: f64 },
+            FeeCharged {
+                amount: f64,
+                causation_event_id: uuid::Uuid,
+            },
+        }
+    }
+}
+
+impl replay::EventStream for IdempotentFeeAccount {
+    type Event = IdempotentFeeAccountEvent;
+
+    fn stream_type() -> String {
+        "IdempotentFeeAccount".to_string()
+    }
+
+    fn apply(&mut self, event: Self::Event) {
+        match event {
+            IdempotentFeeAccountEvent::Opened { balance } => {
+                self.balance = balance;
+            }
+            IdempotentFeeAccountEvent::FeeCharged {
+                amount,
+                causation_event_id,
+            } => {
+                self.balance -= amount;
+                self.applied_causation_ids.insert(causation_event_id);
+            }
+        }
+    }
+}
+
+impl replay::Aggregate for IdempotentFeeAccount {
+    type Command = IdempotentFeeAccountCommand;
+    type Error = replay::Error;
+    type Services = ();
+
+    async fn handle(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        match command {
+            IdempotentFeeAccountCommand::Open { balance } => {
+                Ok(vec![IdempotentFeeAccountEvent::Opened { balance }])
+            }
+            IdempotentFeeAccountCommand::ChargeFee {
+                amount,
+                causation_event_id,
+            } => {
+                // Causation guard recipe: duplicate causation identity is a no-op.
+                if self.applied_causation_ids.contains(&causation_event_id) {
+                    return Ok(Vec::new());
+                }
+
+                Ok(vec![IdempotentFeeAccountEvent::FeeCharged {
+                    amount,
+                    causation_event_id,
+                }])
+            }
+        }
+    }
+}
+
 struct BankAccountStatement {
     bank_account: BankAccountUrn,
     from: chrono::NaiveDate,
@@ -1395,6 +1474,12 @@ struct WithdrawFeePolicyStartAtBeginning {
     fee: f64,
 }
 
+struct ChargeFeeWithCausationPolicy {
+    source: BankAccountUrn,
+    target: IdempotentFeeAccountUrn,
+    fee: f64,
+}
+
 impl replay_persistence::Policy for WithdrawFeePolicy {
     type Event = BankAccountEvent;
 
@@ -1478,6 +1563,37 @@ impl replay_persistence::Policy for WithdrawFeePolicyStartAtBeginning {
                     BankAccountCommand::Withdraw {
                         effective_on: *operation_date,
                         amount: self.fee,
+                    },
+                )]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+impl replay_persistence::Policy for ChargeFeeWithCausationPolicy {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "charge_fee_with_causation_policy"
+    }
+
+    fn stream_filter(&self) -> replay_persistence::StreamFilter {
+        replay_persistence::StreamFilter::with_stream_id::<BankAccount>(&self.source)
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Now
+    }
+
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        match &event.data {
+            BankAccountEvent::Deposited { .. } => {
+                vec![replay_persistence::Dispatch::to::<IdempotentFeeAccount>(
+                    self.target.clone(),
+                    IdempotentFeeAccountCommand::ChargeFee {
+                        amount: self.fee,
+                        causation_event_id: event.id,
                     },
                 )]
             }
@@ -1925,4 +2041,123 @@ async fn policy_daemon_polls_and_reacts_without_manual_drain_postgres_test() {
     );
 
     daemon.shutdown().await;
+}
+
+#[tokio::test]
+async fn policy_duplicate_delivery_is_absorbed_by_causation_guard_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+
+    let source = BankAccountUrn::new("dup-source-1").unwrap();
+    let target = IdempotentFeeAccountUrn::new("dup-target-1").unwrap();
+
+    // Open fee account with a known baseline balance.
+    cqrs.execute::<IdempotentFeeAccount>(
+        &target,
+        replay::Metadata::default(),
+        IdempotentFeeAccountCommand::Open { balance: 100.0 },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<IdempotentFeeAccount>(())
+        .register_policy(ChargeFeeWithCausationPolicy {
+            source: source.clone(),
+            target: target.clone(),
+            fee: 5.0,
+        })
+        .build();
+
+    // Bootstrap StartAt::Now cursor at current head (after target account open,
+    // before source deposit exists).
+    assert_eq!(runner.drain().await.unwrap(), 0);
+
+    // Trigger policy reaction with one source deposit (after policy
+    // registration so StartAt::Now can pick it up).
+    cqrs.execute::<BankAccount>(
+        &source,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // First delivery applies one fee charge.
+    assert_eq!(runner.drain().await.unwrap(), 1);
+    let after_first = cqrs
+        .fetch_aggregate::<IdempotentFeeAccount>(&target)
+        .await
+        .unwrap();
+    assert_eq!(after_first.balance, 95.0);
+
+    let source_event_id: uuid::Uuid = sqlx::query_scalar(
+        "SELECT id FROM events WHERE stream_id = $1 AND type = $2 ORDER BY version ASC LIMIT 1",
+    )
+    .bind(Into::<Urn>::into(source.clone()).to_string())
+    .bind("Deposited")
+    .fetch_one(&pg_pool)
+    .await
+    .expect("source deposited event must exist");
+
+    let first_fee_meta: serde_json::Value = sqlx::query_scalar(
+        "SELECT metadata FROM events WHERE stream_id = $1 AND type = $2 ORDER BY version ASC LIMIT 1",
+    )
+    .bind(Into::<Urn>::into(target.clone()).to_string())
+    .bind("FeeCharged")
+    .fetch_one(&pg_pool)
+    .await
+    .expect("first fee event must exist");
+
+    // Contract: policy-emitted event metadata carries causation identity.
+    assert_eq!(
+        first_fee_meta["causation"]["event_id"],
+        source_event_id.to_string()
+    );
+
+    // Simulate redelivery by rewinding cursor below the source event.
+    sqlx::query("UPDATE policy_cursors SET position = 1 WHERE name = $1")
+        .bind("charge_fee_with_causation_policy")
+        .execute(&pg_pool)
+        .await
+        .expect("cursor rewind update must succeed");
+
+    // Second delivery issues the same causation id, and the aggregate absorbs
+    // it as a no-op.
+    assert_eq!(runner.drain().await.unwrap(), 1);
+
+    let after_second = cqrs
+        .fetch_aggregate::<IdempotentFeeAccount>(&target)
+        .await
+        .unwrap();
+    assert_eq!(after_second.balance, 95.0);
+
+    let fee_event_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE stream_id = $1 AND type = $2")
+            .bind(Into::<Urn>::into(target).to_string())
+            .bind("FeeCharged")
+            .fetch_one(&pg_pool)
+            .await
+            .expect("fee event count query must succeed");
+    assert_eq!(fee_event_count, 1);
 }

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -2161,3 +2161,133 @@ async fn policy_duplicate_delivery_is_absorbed_by_causation_guard_postgres_test(
             .expect("fee event count query must succeed");
     assert_eq!(fee_event_count, 1);
 }
+
+// ── Compaction feed (issue #81) ───────────────────────────────────────────────
+
+/// Policy correctly walks the true log across a compaction boundary.
+///
+/// Scenario (ADR 0004):
+///   1. Two real events are appended: Deposited(100) at gp=1, MonthlyClosed at gp=2.
+///   2. Compact is called: originals archived (compacted_snapshot=false), one synthetic
+///      MonthlyClosed snapshot inserted at gp=3 (compacted_snapshot=true).
+///   3. One more real event is appended after compaction: Deposited(200) at gp=4.
+///   4. A policy with `StartAt::Beginning` is registered and drained.
+///
+/// Acceptance criteria (from the issue):
+///   - Policy processes gp=1 (Deposited) — pre-compaction original       → 1 reaction
+///   - Policy skips   gp=2 (MonthlyClosed) — no matching reaction         → 0 reactions
+///   - Policy skips   gp=3 (synthetic snapshot) without cursor deadlock   → 0 reactions
+///   - Policy processes gp=4 (Deposited) — post-compaction real event     → 1 reaction
+///   - Total dispatches = 2 (not 3, which would indicate the synthetic was
+///     mis-delivered, or 1, which would indicate the cursor stalled at gp=2).
+#[tokio::test]
+async fn policy_lagging_behind_compaction_skips_synthetic_snapshot_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("compaction-feed-1").unwrap();
+    let meta = replay::Metadata::default();
+    let jan_1 = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+    let feb_1 = chrono::NaiveDate::from_ymd_opt(2026, 2, 1).unwrap();
+
+    // ── Pre-compaction: Deposited(100) + MonthlyClosed ────────────────────────
+    cqrs.execute::<BankAccount>(
+        &account,
+        meta.clone(),
+        BankAccountCommand::Deposit {
+            effective_on: jan_1,
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    cqrs.execute::<BankAccount>(
+        &account,
+        meta.clone(),
+        BankAccountCommand::CloseMonth { month: jan_1 },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // ── Compact: archives originals; inserts synthetic snapshot ───────────────
+    let aggregate = cqrs.fetch_aggregate::<BankAccount>(&account).await.unwrap();
+    cqrs.compact(&aggregate, meta.clone()).await.unwrap();
+
+    // Confirm the synthetic row was written with compacted_snapshot = true.
+    let synthetic_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE compacted_snapshot = TRUE")
+            .fetch_one(&pg_pool)
+            .await
+            .expect("synthetic row count query must succeed");
+    assert_eq!(
+        synthetic_count, 1,
+        "compact must produce exactly one synthetic row (the MonthlyClosed snapshot)"
+    );
+
+    // ── Post-compaction: append one more real event ───────────────────────────
+    cqrs.execute::<BankAccount>(
+        &account,
+        meta.clone(),
+        BankAccountCommand::Deposit {
+            effective_on: feb_1,
+            amount: 200.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // At this point the global_position sequence is:
+    //   gp=1  Deposited(100)     real, archived (compacted_snapshot=false)
+    //   gp=2  MonthlyClosed      real, archived (compacted_snapshot=false)
+    //   gp=3  MonthlyClosed snap synthetic      (compacted_snapshot=true)
+    //   gp=4  Deposited(200)     real, live      (compacted_snapshot=false)
+
+    // ── Register a lagging policy that starts from the beginning ─────────────
+    // `WithdrawFeePolicyStartAtBeginning` starts at gp=0, reacts to Deposited.
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(WithdrawFeePolicyStartAtBeginning { fee: 5.0 })
+        .build();
+
+    let dispatches = runner.drain().await.expect("drain must succeed");
+
+    // Two dispatches: gp=1 (Deposited pre-compaction) + gp=4 (Deposited post-compaction).
+    // If dispatches == 3 the synthetic was mis-delivered.
+    // If dispatches < 2 the cursor stalled before gp=4 (gap-detection broken).
+    assert_eq!(
+        dispatches, 2,
+        "policy must react to both real Deposited events and skip the synthetic snapshot"
+    );
+
+    // The cursor must have advanced past the synthetic (gp=3) and reached gp=4.
+    let final_cursor: i64 = sqlx::query_scalar(
+        "SELECT position FROM policy_cursors WHERE name = 'withdraw_fee_policy_start_at_beginning'",
+    )
+    .fetch_one(&pg_pool)
+    .await
+    .expect("cursor must exist after drain");
+
+    assert_eq!(
+        final_cursor, 4,
+        "cursor must have advanced past the synthetic snapshot to the final real event"
+    );
+}

--- a/persistence/tests/migrations/0009_compacted_snapshot.sql
+++ b/persistence/tests/migrations/0009_compacted_snapshot.sql
@@ -1,0 +1,23 @@
+-- Mark synthetic events inserted by compaction so the Policy feed can skip them.
+--
+-- `compact` archives the original live events (UPDATE ... SET aggregate_version = n)
+-- and inserts brand-new rows that represent the compacted state snapshot.  Those
+-- synthetic rows must never be delivered to a Policy, because the real originals
+-- are still present in the log and will (or already have) been delivered.
+--
+-- Design (see ADR 0004):
+--   - compacted_snapshot = FALSE (default): a real event — written by normal `append`
+--     or by archiving during compaction.  The policy feed processes these.
+--   - compacted_snapshot = TRUE: a synthetic snapshot row written in step 6 of
+--     `compact`.  The policy runner advances its cursor past these but does NOT
+--     deliver them to a policy's `react` handler.
+--
+-- The partial index below accelerates the most common policy-feed scan pattern:
+--   SELECT ... FROM events WHERE global_position > $cursor AND compacted_snapshot = false
+--   ORDER BY global_position
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS compacted_snapshot BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_events_policy_feed
+    ON events (global_position)
+    WHERE compacted_snapshot = FALSE;


### PR DESCRIPTION
## Summary

Closes #81.

### Design (ADR 0004)

Compaction archives the original live events in-place and inserts brand-new
synthetic snapshot rows.  Without tagging, a lagging policy either:

- sees both originals **and** synthetics → duplicate delivery of the compacted
  tail, or
- sees only synthetics → skips pre-compaction history entirely.

The fix: tag synthetic rows at write time (`compacted_snapshot = TRUE`) and
teach the policy runner to advance the cursor past them silently.

### Changes

| File | Change |
|---|---|
| `persistence/tests/migrations/0009_compacted_snapshot.sql` | `ALTER TABLE events ADD COLUMN compacted_snapshot BOOLEAN NOT NULL DEFAULT FALSE`; partial index for the feed scan |
| `persistence/src/infrastructure/postgres.rs` | `compact` step 6 INSERT uses `compacted_snapshot = TRUE` for synthetic rows |
| `persistence/src/policy_runner.rs` | `read_feed` selects the new column; gap detection evaluates every row in order (preserves in-flight gap safety); synthetic rows advance the cursor but fire no reaction |
| `persistence/tests/integration_tests.rs` | `policy_lagging_behind_compaction_skips_synthetic_snapshot_postgres_test`: full compaction lifecycle + drain asserting 2 dispatches and final cursor == 4 |

### Key design choice: gap detection

The `read_feed` function stops at the first *missing* position to protect
against in-flight (assigned-but-uncommitted) BIGSERIAL values. Filtering
synthetic rows **in SQL** would create artificial gaps (e.g. gp 1, 2, 4 when
gp=3 is synthetic), freezing the cursor permanently. Instead the column is
**selected** (not filtered); synthetic rows increment `expected` without
producing a feed entry, so the contiguous-prefix invariant is maintained.

### Aggregate replay

Unaffected. `stream_events_by_stream_id` uses `aggregate_version IS NULL`
which naturally selects the compacted synthetic stream.