### PR TITLE
feat(persistence): single active runner per policy via pg_advisory_lock (#82)

### DIFF
--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -177,9 +177,19 @@ impl PolicyRunner {
 
     /// Start one long-lived polling task per registered policy.
     ///
-    /// Each task owns its cursor in task-local state and periodically reads the
-    /// policy feed to execute reactions. Use [`PolicyRunnerDaemon::shutdown`] to
-    /// stop tasks cleanly.
+    /// Each task competes for a per-policy `pg_advisory_lock` before entering its
+    /// polling loop.  The lock key is derived from the policy name, so:
+    ///
+    /// - **Exactly one** service instance is the active leader for each policy at
+    ///   any moment (single-consumer correctness for the ordered global feed).
+    /// - **Different policies** may run on different instances concurrently.
+    /// - **Leader failover is automatic**: the advisory lock is session-scoped, so
+    ///   when the leader's task (or its host process) dies the lock is released and
+    ///   a standby acquires it on the next poll and resumes from the stored cursor.
+    ///
+    /// Use [`PolicyRunnerDaemon::shutdown`] to stop all tasks cleanly.  Shutdown
+    /// explicitly calls `pg_advisory_unlock` so the standby can take over without
+    /// waiting for a TCP-level session timeout.
     pub fn start_polling(&self, interval: Duration) -> PolicyRunnerDaemon {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let mut tasks = Vec::with_capacity(self.policies.len());
@@ -193,44 +203,131 @@ impl PolicyRunner {
 
             tasks.push(tokio::spawn(async move {
                 let name = policy.name().to_string();
-                let mut cursor = match load_cursor(&pool, &name, policy.start_at()).await {
-                    Ok(cursor) => cursor,
-                    Err(error) => {
-                        tracing::error!(
-                            policy = %name,
-                            error = %error,
-                            "policy task failed to initialize cursor"
-                        );
+
+                // Outer loop: repeatedly attempt to acquire the advisory lock.
+                // A standby instance stays in this loop, sleeping between attempts.
+                'acquire: loop {
+                    if *policy_shutdown_rx.borrow() {
                         return;
                     }
-                };
 
-                loop {
-                    if *policy_shutdown_rx.borrow() {
-                        break;
-                    }
-
-                    match drain_policy_once(&cqrs, &pool, &executors, policy.as_ref(), &mut cursor)
-                        .await
-                    {
-                        Ok(_) => {}
+                    // Hold a dedicated connection for the session-scoped lock.
+                    // Keeping this connection alive for the full leadership tenure
+                    // ensures the lock is not silently released between polls.
+                    let mut lock_conn = match pool.acquire().await {
+                        Ok(conn) => conn,
                         Err(error) => {
                             tracing::error!(
                                 policy = %name,
                                 error = %error,
-                                "policy polling iteration failed"
+                                "policy task could not acquire a connection for advisory lock"
                             );
+                            tokio::select! {
+                                _ = policy_shutdown_rx.changed() => {}
+                                _ = tokio::time::sleep(interval) => {}
+                            }
+                            continue 'acquire;
+                        }
+                    };
+
+                    // pg_try_advisory_lock is non-blocking: returns true only when
+                    // this session exclusively holds the lock for `name`.
+                    let acquired = match sqlx::query_scalar::<_, bool>(
+                        "SELECT pg_try_advisory_lock(hashtext($1)::bigint)",
+                    )
+                    .bind(&name)
+                    .fetch_one(&mut *lock_conn)
+                    .await
+                    {
+                        Ok(v) => v,
+                        Err(error) => {
+                            tracing::error!(
+                                policy = %name,
+                                error = %error,
+                                "advisory lock query failed"
+                            );
+                            tokio::select! {
+                                _ = policy_shutdown_rx.changed() => {}
+                                _ = tokio::time::sleep(interval) => {}
+                            }
+                            continue 'acquire;
+                        }
+                    };
+
+                    if !acquired {
+                        tracing::debug!(
+                            policy = %name,
+                            "advisory lock held by another instance; standing by"
+                        );
+                        drop(lock_conn);
+                        tokio::select! {
+                            _ = policy_shutdown_rx.changed() => {}
+                            _ = tokio::time::sleep(interval) => {}
+                        }
+                        continue 'acquire;
+                    }
+
+                    tracing::info!(policy = %name, "acquired advisory lock; running as leader");
+
+                    // Initialize cursor from the stored checkpoint (or bootstrap).
+                    let mut cursor = match load_cursor(&pool, &name, policy.start_at()).await {
+                        Ok(cursor) => cursor,
+                        Err(error) => {
+                            tracing::error!(
+                                policy = %name,
+                                error = %error,
+                                "leader failed to initialize cursor; releasing lock"
+                            );
+                            let _ = sqlx::query("SELECT pg_advisory_unlock(hashtext($1)::bigint)")
+                                .bind(&name)
+                                .execute(&mut *lock_conn)
+                                .await;
+                            return;
+                        }
+                    };
+
+                    // Leadership polling loop.
+                    loop {
+                        if *policy_shutdown_rx.borrow() {
+                            break;
+                        }
+
+                        match drain_policy_once(
+                            &cqrs,
+                            &pool,
+                            &executors,
+                            policy.as_ref(),
+                            &mut cursor,
+                        )
+                        .await
+                        {
+                            Ok(_) => {}
+                            Err(error) => {
+                                tracing::error!(
+                                    policy = %name,
+                                    error = %error,
+                                    "policy polling iteration failed"
+                                );
+                            }
+                        }
+
+                        tokio::select! {
+                            changed = policy_shutdown_rx.changed() => {
+                                if changed.is_err() || *policy_shutdown_rx.borrow() {
+                                    break;
+                                }
+                            }
+                            _ = tokio::time::sleep(interval) => {}
                         }
                     }
 
-                    tokio::select! {
-                        changed = policy_shutdown_rx.changed() => {
-                            if changed.is_err() || *policy_shutdown_rx.borrow() {
-                                break;
-                            }
-                        }
-                        _ = tokio::time::sleep(interval) => {}
-                    }
+                    // Shutdown: explicitly release the lock so a standby can take
+                    // over immediately (without waiting for a TCP session timeout).
+                    let _ = sqlx::query("SELECT pg_advisory_unlock(hashtext($1)::bigint)")
+                        .bind(&name)
+                        .execute(&mut *lock_conn)
+                        .await;
+                    return;
                 }
             }));
         }

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -2291,3 +2291,182 @@ async fn policy_lagging_behind_compaction_skips_synthetic_snapshot_postgres_test
         "cursor must have advanced past the synthetic snapshot to the final real event"
     );
 }
+
+// ── Single active runner via pg_advisory_lock (issue #82) ────────────────────
+
+/// A minimal policy used only by the advisory-lock tests.
+struct SingleRunnerPolicy;
+
+impl replay_persistence::Policy for SingleRunnerPolicy {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "single_runner_policy"
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Now
+    }
+
+    /// React to every `Deposited` event by issuing a `Withdraw` of $1.
+    /// `Withdrawn` is not a `Deposited`, so the reaction does not feed itself.
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        match &event.data {
+            BankAccountEvent::Deposited { operation_date, .. } => {
+                let account = BankAccountUrn::try_from(event.stream_id.clone())
+                    .expect("deposit events live on bank-account streams");
+                vec![replay_persistence::Dispatch::to::<BankAccount>(
+                    account,
+                    BankAccountCommand::Withdraw {
+                        effective_on: *operation_date,
+                        amount: 1.0,
+                    },
+                )]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// Two runners competing for the same policy do not double-process events, and
+/// the surviving runner resumes from the stored cursor after the leader stops.
+///
+/// Scenario:
+///   1. Two `PolicyRunner` instances are created with identical `SingleRunnerPolicy`.
+///   2. Both start polling. Exactly one acquires the advisory lock and becomes
+///      the leader; the other stands by.
+///   3. Two deposits are appended. Only the leader reacts → exactly 2 Withdrawn
+///      events. If both ran, we would see 4.
+///   4. The first daemon is shut down (explicit `pg_advisory_unlock`). The standby
+///      acquires the lock and resumes from the stored cursor.
+///   5. Two more deposits are appended. The new leader reacts → 2 additional
+///      Withdrawn events. Total = 4.
+#[tokio::test]
+async fn policy_single_active_runner_via_advisory_lock_postgres_test() {
+    use std::time::Duration;
+
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("advisory-lock-1").unwrap();
+    let meta = replay::Metadata::default();
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+
+    // ── Helper: count Withdrawn events in the database ────────────────────────
+    let count_withdrawn = || {
+        let pool = pg_pool.clone();
+        async move {
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM events WHERE type = 'Withdrawn'")
+                .fetch_one(&pool)
+                .await
+                .expect("count query must succeed")
+        }
+    };
+
+    // Convenience builder so both runners are configured identically.
+    let build_runner = || {
+        replay_persistence::PolicyRunner::builder(cqrs.clone())
+            .register_services::<BankAccount>(())
+            .register_policy(SingleRunnerPolicy)
+            .build()
+    };
+
+    let interval = Duration::from_millis(50);
+
+    // ── Phase 1: two daemons, only the leader reacts ──────────────────────────
+    let daemon_a = build_runner().start_polling(interval);
+    let daemon_b = build_runner().start_polling(interval);
+
+    // Give both tasks time to start and one to acquire the lock.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    cqrs.execute::<BankAccount>(
+        &account,
+        meta.clone(),
+        BankAccountCommand::Deposit {
+            effective_on: date,
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    cqrs.execute::<BankAccount>(
+        &account,
+        meta.clone(),
+        BankAccountCommand::Deposit {
+            effective_on: date,
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Allow enough polling cycles for the leader to react.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let withdrawn_after_phase1 = count_withdrawn().await;
+    assert_eq!(
+        withdrawn_after_phase1, 2,
+        "only the leader must react; if both ran the count would be 4"
+    );
+
+    // ── Phase 2: shut down daemon_a; standby acquires lock and resumes ────────
+    daemon_a.shutdown().await;
+
+    // Give the surviving daemon time to notice the lock is free and become leader.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    cqrs.execute::<BankAccount>(
+        &account,
+        meta.clone(),
+        BankAccountCommand::Deposit {
+            effective_on: date,
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    cqrs.execute::<BankAccount>(
+        &account,
+        meta.clone(),
+        BankAccountCommand::Deposit {
+            effective_on: date,
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Allow the new leader to react to the two new deposits.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let withdrawn_after_phase2 = count_withdrawn().await;
+    assert_eq!(
+        withdrawn_after_phase2, 4,
+        "the standby must have resumed from the stored cursor and reacted to the two new deposits"
+    );
+
+    daemon_b.shutdown().await;
+}


### PR DESCRIPTION
## Summary

Closes #82.

### Design (ADR-0003)

Global event order is a **correctness property** of policies: only a single sequential consumer draining `global_position` in order preserves it. This PR enforces that guarantee across multiple service replicas using Postgres advisory locks — zero new infrastructure.

### How it works

Each `start_polling` task wraps its polling loop in an outer `'acquire` loop:

1. **Acquire** a pool connection and call `pg_try_advisory_lock(hashtext(policy_name)::bigint)` (non-blocking).
2. **Standby**: if the lock is held by another session, drop the connection, sleep one interval, retry.
3. **Leader**: hold the connection for the entire tenure (keeping the session-scoped lock alive), load the stored cursor, run the inner polling loop.
4. **Shutdown**: call `pg_advisory_unlock` before returning the connection so the standby can take over immediately without waiting for a TCP session timeout.

The lock key is derived per-policy from `hashtext(name)::bigint`, so different policies can run on different instances concurrently.

### Changes

| File | Change |
|---|---|
| `persistence/src/policy_runner.rs` | `start_polling` gains outer `'acquire` loop with `pg_try_advisory_lock` / `pg_advisory_unlock` |
| `persistence/tests/integration_tests.rs` | `policy_single_active_runner_via_advisory_lock_postgres_test` |

### Test coverage

- **No double-processing**: two daemons for identical policy, 2 deposits → assert exactly 2 `Withdrawn` events (not 4).
- **Standby resumes**: shut down `daemon_a`, append 2 more deposits → assert total 4 `Withdrawn` (new leader picked up from stored cursor).