### PR TITLE
feat(persistence): loop prevention via causation-depth limit (#83)

### DIFF
--- a/persistence/src/policy.rs
+++ b/persistence/src/policy.rs
@@ -117,6 +117,20 @@ pub trait Policy: Send + Sync {
         StartAt::Now
     }
 
+    /// Maximum causation depth this policy will react to.  The runner skips any
+    /// event whose `causation.depth` is ≥ this value and logs loudly instead,
+    /// acting as a circuit breaker for runaway event → command → event cascades.
+    ///
+    /// Resolution order (most-specific-first):
+    ///   1. This per-policy override (when `Some`).
+    ///   2. Environment variable `REPLAY_MAX_CAUSATION_DEPTH`.
+    ///   3. Built-in default (10).
+    ///
+    /// Return `None` to defer to the global env var / built-in default.
+    fn max_causation_depth(&self) -> Option<u32> {
+        None
+    }
+
     /// Pure reaction: given an event, return the commands to dispatch.
     ///
     /// Invariant: because delivery is at-least-once, target aggregate command
@@ -136,6 +150,8 @@ pub(crate) trait ErasedPolicy: Send + Sync {
 
     fn start_at(&self) -> StartAt;
 
+    fn max_causation_depth_erased(&self) -> Option<u32>;
+
     fn react_erased(&self, raw: &PersistedEvent<serde_json::Value>) -> Vec<Dispatch>;
 }
 
@@ -150,6 +166,10 @@ impl<P: Policy> ErasedPolicy for P {
 
     fn start_at(&self) -> StartAt {
         Policy::start_at(self)
+    }
+
+    fn max_causation_depth_erased(&self) -> Option<u32> {
+        Policy::max_causation_depth(self)
     }
 
     fn react_erased(&self, raw: &PersistedEvent<serde_json::Value>) -> Vec<Dispatch> {

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::BoxFuture;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sqlx::{Pool, Postgres, QueryBuilder, Row};
 use tokio::sync::watch;
@@ -287,6 +288,7 @@ impl PolicyRunner {
                     };
 
                     // Leadership polling loop.
+                    let max_depth = resolve_max_depth(policy.as_ref());
                     loop {
                         if *policy_shutdown_rx.borrow() {
                             break;
@@ -298,6 +300,7 @@ impl PolicyRunner {
                             &executors,
                             policy.as_ref(),
                             &mut cursor,
+                            max_depth,
                         )
                         .await
                         {
@@ -338,7 +341,16 @@ impl PolicyRunner {
     async fn drain_policy(&self, policy: &dyn ErasedPolicy) -> Result<usize, replay::Error> {
         let name = policy.name().to_string();
         let mut cursor = load_cursor(&self.pool, &name, policy.start_at()).await?;
-        drain_policy_once(&self.cqrs, &self.pool, &self.executors, policy, &mut cursor).await
+        let max_depth = resolve_max_depth(policy);
+        drain_policy_once(
+            &self.cqrs,
+            &self.pool,
+            &self.executors,
+            policy,
+            &mut cursor,
+            max_depth,
+        )
+        .await
     }
 }
 
@@ -348,6 +360,7 @@ async fn drain_policy_once(
     executors: &HashMap<TypeId, Arc<dyn AggregateExecutor>>,
     policy: &dyn ErasedPolicy,
     cursor: &mut i64,
+    max_depth: u32,
 ) -> Result<usize, replay::Error> {
     let name = policy.name().to_string();
     let feed = read_feed(pool, policy.stream_filter(), *cursor).await?;
@@ -355,15 +368,33 @@ async fn drain_policy_once(
     let mut executed = 0;
     for (global_position, maybe_raw) in feed {
         if let Some(raw) = maybe_raw {
-            // Real event: deliver to the policy and execute all returned dispatches.
-            for dispatch in policy.react_erased(&raw) {
-                execute_dispatch(cqrs, executors, &name, global_position, &raw, dispatch).await?;
-                executed += 1;
+            let depth = event_causation_depth(&raw);
+            if depth >= max_depth {
+                // Circuit breaker: the event's causation chain is too deep.
+                // Skip reactions but keep advancing so the policy is not wedged.
+                let (_, limit_source) = resolve_max_depth_with_source(policy);
+                tracing::warn!(
+                    policy        = %name,
+                    event_id      = %raw.id,
+                    stream_id     = %raw.stream_id,
+                    global_position,
+                    depth,
+                    max_depth,
+                    limit_source,
+                    causation_chain = ?parse_causation_info(&raw),
+                    "causation depth limit reached; skipping reaction to prevent runaway cascade"
+                );
+            } else {
+                // Real event within depth budget: deliver to the policy.
+                for dispatch in policy.react_erased(&raw) {
+                    execute_dispatch(cqrs, executors, &name, global_position, &raw, dispatch)
+                        .await?;
+                    executed += 1;
+                }
             }
         }
-        // Advance cursor regardless of whether the row was a real event or a synthetic
-        // compaction snapshot.  Synthetics must still move the cursor forward so the
-        // next poll does not re-process positions the runner has already seen.
+        // Advance cursor regardless: synthetic rows, depth-limited events, and
+        // normally-processed events all move the checkpoint forward.
         save_cursor(pool, &name, global_position).await?;
         *cursor = global_position;
     }
@@ -529,24 +560,92 @@ async fn save_cursor(
     Ok(())
 }
 
+/// Typed representation of the `causation` block stamped in event metadata by
+/// every policy reaction.  Using a struct instead of manual `Value` navigation
+/// ensures the write (serialization) and read (deserialization) paths stay in sync.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CausationInfo {
+    policy: String,
+    event_id: String,
+    stream_id: String,
+    global_position: i64,
+    /// How many policy hops deep this event is.  Root events (from normal
+    /// `append`) carry no causation block and are treated as depth 0.
+    #[serde(default)]
+    depth: u32,
+}
+
+/// Top-level metadata payload written by the runner for each policy-issued command.
+#[derive(Debug, Serialize)]
+struct CausationPayload {
+    causation: CausationInfo,
+}
+
 /// Causation metadata stamped on every command a policy issues.
 ///
-/// Records which policy reacted and which event triggered it. This is the seed
-/// of the causation chain that later slices use for idempotency (#80) and
-/// loop-depth limiting (#83).
+/// Records which policy reacted and which event triggered it, and increments the
+/// causation depth so the runner can detect runaway event→command→event cascades.
 fn causation_metadata(
     policy_name: &str,
     global_position: i64,
     raw: &PersistedEvent<Value>,
 ) -> Metadata {
-    Metadata::new(serde_json::json!({
-        "causation": {
-            "policy": policy_name,
-            "event_id": raw.id.to_string(),
-            "stream_id": raw.stream_id.to_string(),
-            "global_position": global_position,
+    Metadata::new(CausationPayload {
+        causation: CausationInfo {
+            policy: policy_name.to_string(),
+            event_id: raw.id.to_string(),
+            stream_id: raw.stream_id.to_string(),
+            global_position,
+            depth: event_causation_depth(raw) + 1,
+        },
+    })
+}
+
+/// Extract the causation depth from an event's metadata.
+///
+/// Events written by normal `append` calls carry no `causation` block and are
+/// treated as depth 0 (the root of a potential chain).  Events emitted by policy
+/// reactions carry the depth stamped in [`causation_metadata`].
+fn event_causation_depth(raw: &PersistedEvent<Value>) -> u32 {
+    parse_causation_info(raw).map(|c| c.depth).unwrap_or(0)
+}
+
+/// Deserialize the `causation` block from an event's metadata, if present.
+fn parse_causation_info(raw: &PersistedEvent<Value>) -> Option<CausationInfo> {
+    raw.metadata
+        .to_json()
+        .get("causation")
+        .cloned()
+        .and_then(|v| serde_json::from_value(v).ok())
+}
+
+/// Built-in default maximum causation depth (circuit-breaker for loops).
+const DEFAULT_MAX_CAUSATION_DEPTH: u32 = 10;
+
+/// Environment variable that overrides the built-in depth limit.
+const CAUSATION_DEPTH_ENV_VAR: &str = "REPLAY_MAX_CAUSATION_DEPTH";
+
+/// Resolve the effective causation depth limit for a policy.
+///
+/// Precedence (most-specific wins):
+///   1. Per-policy override via [`Policy::max_causation_depth`]
+///   2. `REPLAY_MAX_CAUSATION_DEPTH` environment variable
+///   3. Built-in default (10)
+fn resolve_max_depth(policy: &dyn ErasedPolicy) -> u32 {
+    resolve_max_depth_with_source(policy).0
+}
+
+/// Like [`resolve_max_depth`] but also returns the source for diagnostic logging.
+fn resolve_max_depth_with_source(policy: &dyn ErasedPolicy) -> (u32, &'static str) {
+    if let Some(d) = policy.max_causation_depth_erased() {
+        return (d, "policy override");
+    }
+    if let Ok(s) = std::env::var(CAUSATION_DEPTH_ENV_VAR) {
+        if let Ok(d) = s.parse::<u32>() {
+            return (d, CAUSATION_DEPTH_ENV_VAR);
         }
-    }))
+    }
+    (DEFAULT_MAX_CAUSATION_DEPTH, "built-in default")
 }
 
 fn merge_dispatch_metadata(

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -2470,3 +2470,138 @@ async fn policy_single_active_runner_via_advisory_lock_postgres_test() {
 
     daemon_b.shutdown().await;
 }
+
+// ── Loop prevention via causation-depth limit (issue #83) ────────────────────
+
+/// A policy that deliberately creates a loop: every `Deposited` event triggers
+/// another `Deposit` command on the same account. Without the depth limit this
+/// would run forever.
+struct LoopPolicy {
+    max_depth: u32,
+}
+
+impl replay_persistence::Policy for LoopPolicy {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "loop_policy"
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Beginning
+    }
+
+    fn max_causation_depth(&self) -> Option<u32> {
+        Some(self.max_depth)
+    }
+
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        match &event.data {
+            BankAccountEvent::Deposited { operation_date, .. } => {
+                let account = BankAccountUrn::try_from(event.stream_id.clone())
+                    .expect("deposit events live on bank-account streams");
+                // Self-trigger: deposit $1 back, which creates another Deposited.
+                vec![replay_persistence::Dispatch::to::<BankAccount>(
+                    account,
+                    BankAccountCommand::Deposit {
+                        effective_on: *operation_date,
+                        amount: 1.0,
+                    },
+                )]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// A self-triggering policy stops at the configured causation-depth limit.
+///
+/// Scenario (max_depth = 3):
+///   - gp=1  Deposited (depth=0) → reacts → gp=2 Deposited (depth=1)
+///   - gp=2  Deposited (depth=1) → reacts → gp=3 Deposited (depth=2)
+///   - gp=3  Deposited (depth=2) → reacts → gp=4 Deposited (depth=3)
+///   - gp=4  Deposited (depth=3 ≥ max_depth=3) → circuit-breaker fires, skipped
+///
+/// Exactly 3 reactions, 4 total Deposited events, cursor at gp=4.
+#[tokio::test]
+async fn policy_causation_depth_limit_stops_loop_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("loop-1").unwrap();
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+
+    // Seed: one initial deposit at depth 0 (no causation metadata).
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: date,
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(LoopPolicy { max_depth: 3 })
+        .build();
+
+    // Drain until the chain stabilises (circuit breaker fires and no more reactions).
+    // The upper bound of 10 ensures the test terminates even if the limit is broken.
+    let mut rounds: Vec<usize> = Vec::new();
+    for _ in 0..10 {
+        let n = runner.drain().await.expect("drain must not error");
+        rounds.push(n);
+        if n == 0 {
+            break;
+        }
+    }
+
+    // The chain must have stopped cleanly: 1 reaction per drain, then 0.
+    assert_eq!(
+        rounds,
+        vec![1, 1, 1, 0],
+        "expected 3 reactions (depths 0→1, 1→2, 2→3) then the circuit breaker to fire"
+    );
+
+    // Exactly 4 Deposited events in the DB (depths 0, 1, 2, 3).
+    let deposited_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE type = 'Deposited'")
+            .fetch_one(&pg_pool)
+            .await
+            .expect("count query must succeed");
+    assert_eq!(
+        deposited_count, 4,
+        "chain must have produced exactly 4 Deposited events"
+    );
+
+    // The last event must carry causation.depth = 3 in its metadata.
+    let last_meta: serde_json::Value = sqlx::query_scalar(
+        "SELECT metadata FROM events WHERE type = 'Deposited' ORDER BY global_position DESC LIMIT 1",
+    )
+    .fetch_one(&pg_pool)
+    .await
+    .expect("last deposited event must exist");
+
+    assert_eq!(
+        last_meta["causation"]["depth"],
+        serde_json::json!(3),
+        "last event in the chain must be at causation depth 3"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #83.

### Design (ADR-0003)

A policy author implicitly declares a DAG of event→command→event that the library cannot verify. A code change can introduce a back-edge that creates an infinite cascade. This PR adds a runtime circuit-breaker keyed on **causation depth**.

### How it works

Every command a policy issues is stamped with `causation.depth = triggering_event.depth + 1`. Events from normal `append` calls have no depth field (treated as 0). Before calling `react`, the runner checks:

```
if event.causation.depth >= max_depth → skip, warn loudly, advance cursor
```

The limit is a circuit breaker (not a poison pill): the policy keeps advancing; only that one event's reactions are suppressed.

**Resolution order** (most-specific wins):
1. `Policy::max_causation_depth()` override (new optional trait method)
2. `REPLAY_MAX_CAUSATION_DEPTH` environment variable
3. Built-in default: **10**

### Changes

| File | Change |
|---|---|
| `policy.rs` | `Policy::max_causation_depth() → Option<u32>` (default `None`); `ErasedPolicy::max_causation_depth_erased` |
| `policy_runner.rs` | `causation_metadata` stamps `depth`; `event_causation_depth` helper; `resolve_max_depth` / `resolve_max_depth_with_source`; `drain_policy_once` checks depth, logs with chain + limit source |
| `integration_tests.rs` | `LoopPolicy` (self-triggering, max_depth=3) + `policy_causation_depth_limit_stops_loop_postgres_test` |

### Test

With `max_depth=3` and one seed deposit:
- drain rounds: `[1, 1, 1, 0]` (3 reactions then circuit-breaker fires)
- 4 total `Deposited` events at depths 0→1→2→3
- Last event metadata asserts `causation.depth == 3`