### PR TITLE
feat(persistence): failure handling and policy_dead_letters (#84)

### DIFF
--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -51,6 +51,7 @@ struct TypedExecutor<A: Aggregate> {
 impl<A> AggregateExecutor for TypedExecutor<A>
 where
     A: Aggregate + 'static,
+    A::Error: Into<replay::Error>,
     A::StreamId: 'static,
     A::Command: 'static,
     A::Services: Send + Sync + 'static,
@@ -73,10 +74,7 @@ where
             cqrs.execute::<A>(&id, metadata, command, &self.services, expected_version)
                 .await
                 .map(|_| ())
-                .map_err(|e| {
-                    replay::Error::internal(format!("policy command failed: {e}"))
-                        .with_operation("policy_execute")
-                })
+                .map_err(Into::into)
         })
     }
 }
@@ -96,6 +94,7 @@ impl PolicyRunnerBuilder {
     pub fn register_services<A>(mut self, services: A::Services) -> Self
     where
         A: Aggregate + 'static,
+        A::Error: Into<replay::Error>,
         A::StreamId: 'static,
         A::Command: 'static,
         A::Services: Send + Sync + 'static,
@@ -354,6 +353,17 @@ impl PolicyRunner {
     }
 }
 
+/// Maximum number of times a retryable dispatch error is retried before the
+/// event is dead-lettered.  Each retry is preceded by an exponential back-off
+/// starting at 100 ms.
+const MAX_DISPATCH_RETRIES: u32 = 3;
+
+/// Returns `true` for errors whose cause may be transient and worth retrying.
+fn is_retryable(kind: replay::ErrorKind) -> bool {
+    use replay::ErrorKind::{Conflict, RateLimited, Unavailable};
+    matches!(kind, Unavailable | RateLimited | Conflict)
+}
+
 async fn drain_policy_once(
     cqrs: &Cqrs<PostgresEventStore>,
     pool: &Pool<Postgres>,
@@ -385,12 +395,18 @@ async fn drain_policy_once(
                     "causation depth limit reached; skipping reaction to prevent runaway cascade"
                 );
             } else {
-                // Real event within depth budget: deliver to the policy.
-                for dispatch in policy.react_erased(&raw) {
-                    execute_dispatch(cqrs, executors, &name, global_position, &raw, dispatch)
-                        .await?;
-                    executed += 1;
-                }
+                // Real event within depth budget: deliver to the policy with
+                // the full resilience policy (BRV advance, retry, dead-letter).
+                executed += execute_event_reactions(
+                    cqrs,
+                    pool,
+                    executors,
+                    policy,
+                    &name,
+                    global_position,
+                    &raw,
+                )
+                .await?;
             }
         }
         // Advance cursor regardless: synthetic rows, depth-limited events, and
@@ -400,6 +416,115 @@ async fn drain_policy_once(
     }
 
     Ok(executed)
+}
+
+/// Execute all reactions for one event, applying the resilience policy:
+///
+/// | Outcome                             | Action                                |
+/// |-------------------------------------|---------------------------------------|
+/// | `Ok`                                | count as executed, continue           |
+/// | `BusinessRuleViolation`             | log + advance (aggregate said no)     |
+/// | Retryable (`Unavailable`, `Conflict`, `RateLimited`) within retry budget | back-off + retry |
+/// | Permanent or retries exhausted      | write `policy_dead_letters`, advance  |
+///
+/// The function always returns `Ok`; failures are absorbed here so the caller's
+/// cursor always advances (a circuit-breaker, never a poison pill).
+///
+/// **Re-react safety**: on retry the policy's `react` is called again for the
+/// same event.  Because `react` is a pure function and the at-least-once +
+/// causation-guard contract already guarantees idempotency, re-executing an
+/// earlier dispatch that already succeeded is safe.
+async fn execute_event_reactions(
+    cqrs: &Cqrs<PostgresEventStore>,
+    pool: &Pool<Postgres>,
+    executors: &HashMap<TypeId, Arc<dyn AggregateExecutor>>,
+    policy: &dyn ErasedPolicy,
+    policy_name: &str,
+    global_position: i64,
+    raw: &PersistedEvent<Value>,
+) -> Result<usize, replay::Error> {
+    for attempt in 0..=MAX_DISPATCH_RETRIES {
+        let dispatches = policy.react_erased(raw);
+        let mut executed = 0usize;
+        let mut need_retry = false;
+
+        for dispatch in dispatches {
+            match execute_dispatch(cqrs, executors, policy_name, global_position, raw, dispatch)
+                .await
+            {
+                Ok(()) => {
+                    executed += 1;
+                }
+                Err(e) if e.kind() == replay::ErrorKind::BusinessRuleViolation => {
+                    tracing::info!(
+                        policy          = %policy_name,
+                        event_id        = %raw.id,
+                        global_position,
+                        error           = %e,
+                        "policy dispatch declined by aggregate business rule; advancing cursor"
+                    );
+                }
+                Err(e) if is_retryable(e.kind()) && attempt < MAX_DISPATCH_RETRIES => {
+                    tracing::warn!(
+                        policy          = %policy_name,
+                        event_id        = %raw.id,
+                        global_position,
+                        attempt,
+                        error           = %e,
+                        "policy dispatch failed with retryable error; backing off before retry"
+                    );
+                    need_retry = true;
+                    break; // skip remaining dispatches for this attempt
+                }
+                Err(e) => {
+                    // Permanent error, or retryable but retries exhausted.
+                    tracing::error!(
+                        policy          = %policy_name,
+                        event_id        = %raw.id,
+                        global_position,
+                        attempt,
+                        error           = %e,
+                        "policy dispatch failed permanently; writing dead-letter and advancing cursor"
+                    );
+                    write_dead_letter(pool, policy_name, global_position, raw, &e).await?;
+                }
+            }
+        }
+
+        if !need_retry {
+            return Ok(executed);
+        }
+
+        // Exponential back-off: 100 ms, 200 ms, 400 ms, …
+        let backoff = Duration::from_millis(100 * (1u64 << attempt.min(5)));
+        tokio::time::sleep(backoff).await;
+    }
+
+    Ok(0)
+}
+
+/// Write a dead-letter record for a dispatch that could not be executed.
+async fn write_dead_letter(
+    pool: &Pool<Postgres>,
+    policy_name: &str,
+    global_position: i64,
+    raw: &PersistedEvent<Value>,
+    error: &replay::Error,
+) -> Result<(), replay::Error> {
+    sqlx::query(
+        "INSERT INTO policy_dead_letters \
+         (policy_name, global_position, event_id, error_kind, error_message) \
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(policy_name)
+    .bind(global_position)
+    .bind(raw.id)
+    .bind(error.kind().to_string())
+    .bind(error.to_string())
+    .execute(pool)
+    .await
+    .map_err(crate::db_error)?;
+    Ok(())
 }
 
 /// Read the contiguous, gap-free prefix of events with `global_position >

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -2605,3 +2605,235 @@ async fn policy_causation_depth_limit_stops_loop_postgres_test() {
         "last event in the chain must be at causation depth 3"
     );
 }
+
+// ── Failure handling and policy_dead_letters (issue #84) ─────────────────────
+
+/// Policy that dispatches to an aggregate type that is NOT registered in the
+/// runner, producing a permanent `InvalidInput` error every time.
+struct PoisonDispatchPolicy;
+
+impl replay_persistence::Policy for PoisonDispatchPolicy {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "poison_dispatch_policy"
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Beginning
+    }
+
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        if matches!(event.data, BankAccountEvent::Deposited { .. }) {
+            // Dispatch to IdempotentFeeAccount — which will NOT be registered in
+            // the runner, triggering a permanent InvalidInput error.
+            let target = IdempotentFeeAccountUrn::new("unregistered-target").unwrap();
+            vec![replay_persistence::Dispatch::to::<IdempotentFeeAccount>(
+                target,
+                IdempotentFeeAccountCommand::Open { balance: 0.0 },
+            )]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+/// Policy that dispatches a Withdraw command that the aggregate will reject
+/// with a BusinessRuleViolation (insufficient funds).
+struct InsufficientFundsPolicy;
+
+impl replay_persistence::Policy for InsufficientFundsPolicy {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "insufficient_funds_policy"
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Beginning
+    }
+
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        match &event.data {
+            BankAccountEvent::Deposited { operation_date, .. } => {
+                let account = BankAccountUrn::try_from(event.stream_id.clone())
+                    .expect("deposit events live on bank-account streams");
+                // Withdraw more than any realistic balance → BusinessRuleViolation.
+                vec![replay_persistence::Dispatch::to::<BankAccount>(
+                    account,
+                    BankAccountCommand::Withdraw {
+                        effective_on: *operation_date,
+                        amount: 999_999.0,
+                    },
+                )]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// A permanently-failing policy dispatch is dead-lettered and the policy advances.
+///
+/// Scenario:
+///   - Append 2 deposits.
+///   - `PoisonDispatchPolicy` reacts to each but dispatches to an unregistered
+///     aggregate type → permanent `InvalidInput` error each time.
+///   - Both dispatches must be dead-lettered; cursor advances past both events.
+///   - A third, clean event (another deposit) is then appended and processed by
+///     a second, healthy policy to prove the runner is not wedged.
+#[tokio::test]
+async fn policy_permanent_failure_is_dead_lettered_and_advances_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("dead-letter-1").unwrap();
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+    let meta = replay::Metadata::default();
+
+    // Append two deposits that will each produce a permanent dispatch failure.
+    for _ in 0..2 {
+        cqrs.execute::<BankAccount>(
+            &account,
+            meta.clone(),
+            BankAccountCommand::Deposit {
+                effective_on: date,
+                amount: 100.0,
+            },
+            &(),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    // PoisonDispatchPolicy dispatches to IdempotentFeeAccount which is NOT
+    // registered in the runner.  No services are added for it intentionally.
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(PoisonDispatchPolicy)
+        .build();
+
+    // Drain: both events are processed, both dispatches dead-lettered, 0 commands executed.
+    let dispatches = runner.drain().await.expect("drain must not error");
+    assert_eq!(
+        dispatches, 0,
+        "permanently-failing dispatches must not be counted as executed"
+    );
+
+    // Two dead-letter rows must exist.
+    let dead_letter_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM policy_dead_letters WHERE policy_name = 'poison_dispatch_policy'",
+    )
+    .fetch_one(&pg_pool)
+    .await
+    .expect("dead-letter count query must succeed");
+
+    assert_eq!(
+        dead_letter_count, 2,
+        "one dead-letter row per failing dispatch"
+    );
+
+    // Cursor must have advanced past both events (policy is not wedged).
+    let cursor: i64 = sqlx::query_scalar(
+        "SELECT position FROM policy_cursors WHERE name = 'poison_dispatch_policy'",
+    )
+    .fetch_one(&pg_pool)
+    .await
+    .expect("cursor must exist after drain");
+
+    assert_eq!(
+        cursor, 2,
+        "cursor must have advanced past both dead-lettered events"
+    );
+}
+
+/// A BusinessRuleViolation from a dispatch is treated as handled: the cursor
+/// advances without writing a dead-letter record.
+///
+/// Scenario:
+///   - Append a deposit of $10; account balance = 10.
+///   - `InsufficientFundsPolicy` reacts by attempting to withdraw $999 999
+///     → the aggregate returns BusinessRuleViolation (insufficient funds).
+///   - Drain must return 0 dispatches executed (the command was declined).
+///   - No dead-letter row must be written.
+///   - Cursor advances.
+#[tokio::test]
+async fn policy_business_rule_violation_advances_without_dead_letter_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("brv-1").unwrap();
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: date,
+            amount: 10.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(InsufficientFundsPolicy)
+        .build();
+
+    // Drain: the Withdraw is rejected with BusinessRuleViolation; drain does not error.
+    let dispatches = runner.drain().await.expect("drain must not error on BRV");
+    assert_eq!(
+        dispatches, 0,
+        "a BRV-declined command must not be counted as executed"
+    );
+
+    // No dead-letter rows: BRV is not a failure, just the aggregate saying no.
+    let dead_letter_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM policy_dead_letters WHERE policy_name = 'insufficient_funds_policy'",
+    )
+    .fetch_one(&pg_pool)
+    .await
+    .expect("dead-letter count query must succeed");
+
+    assert_eq!(
+        dead_letter_count, 0,
+        "BRV must not produce a dead-letter record"
+    );
+
+    // Cursor advances: the policy is not wedged by the rejection.
+    let cursor: i64 = sqlx::query_scalar(
+        "SELECT position FROM policy_cursors WHERE name = 'insufficient_funds_policy'",
+    )
+    .fetch_one(&pg_pool)
+    .await
+    .expect("cursor must exist after drain");
+
+    assert_eq!(cursor, 1, "cursor must have advanced past the BRV event");
+}

--- a/persistence/tests/migrations/0010_policy_dead_letters.sql
+++ b/persistence/tests/migrations/0010_policy_dead_letters.sql
@@ -1,0 +1,27 @@
+-- Dead-letter store for policy reactions that fail permanently.
+--
+-- When a policy dispatch exhausts its retry budget (or fails with a non-retryable
+-- error) the runner writes one row here and advances the cursor so the policy is
+-- never wedged by a single bad event.  The record is queryable so operators can
+-- triage, replay, or discard failed reactions.
+--
+-- Columns:
+--   id              — surrogate key, auto-generated.
+--   policy_name     — stable policy name (cursor key), e.g. "fee_policy".
+--   global_position — position of the triggering event in the global feed.
+--   event_id        — UUID of the triggering event (for direct lookup / replay).
+--   error_kind      — ErrorKind text (Permanent, Conflict, …) for filtering.
+--   error_message   — human-readable error detail for triage.
+--   created_at      — when the dead-letter was written.
+CREATE TABLE IF NOT EXISTS policy_dead_letters (
+    id               BIGSERIAL   PRIMARY KEY,
+    policy_name      TEXT        NOT NULL,
+    global_position  BIGINT      NOT NULL,
+    event_id         UUID        NOT NULL,
+    error_kind       TEXT        NOT NULL,
+    error_message    TEXT        NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dead_letters_policy
+    ON policy_dead_letters (policy_name, created_at DESC);


### PR DESCRIPTION
Closes #84

## Summary

Implements the failure-handling contract for policy dispatch.

### Resilience strategy (applied per-event in `execute_event_reactions`)

| Outcome | Action |
|---|---|
| `Ok` | count as executed, advance cursor |
| `BusinessRuleViolation` | log `INFO` + advance (aggregate said no, not a failure) |
| `Unavailable` / `Conflict` / `RateLimited` within budget | exponential back-off (100 ms × 2ⁿ) + retry up to 3 times |
| Permanent or retries exhausted | write `policy_dead_letters`, advance cursor |

A policy is never wedged by a single bad event; the cursor always advances.

### Key changes

- **`execute_event_reactions`** — new function that wraps the dispatch loop with the full resilience policy (BRV absorb, bounded retry, dead-letter).
- **`drain_policy_once`** — delegates to `execute_event_reactions` instead of an inline dispatch loop.
- **`TypedExecutor::execute`** — now propagates the original `ErrorKind` by adding `A::Error: Into<replay::Error>` bound (previously all errors were silently converted to `Internal`, breaking BRV detection).
- **Migration `0010_policy_dead_letters.sql`** — `policy_dead_letters` table with BIGSERIAL PK, indexed by `(policy_name, created_at DESC)`.

### Tests (29 total, all green)

| Test | Scenario |
|---|---|
| `policy_permanent_failure_is_dead_lettered_and_advances` | dispatch to unregistered aggregate → `InvalidInput` (permanent) → 2 dead-letter rows, cursor at position 2, 0 commands executed |
| `policy_business_rule_violation_advances_without_dead_letter` | Withdraw  999 from  account → BRV → 0 dead-letter rows, cursor advances, drain does not error |