### PR TITLE
feat(persistence): batched reads and checkpoints for policy runner (#85)

### DIFF
--- a/persistence/src/policy.rs
+++ b/persistence/src/policy.rs
@@ -131,6 +131,29 @@ pub trait Policy: Send + Sync {
         None
     }
 
+    /// Maximum number of events fetched from the feed in a single drain call.
+    ///
+    /// Resolution order (most-specific-first):
+    ///   1. This per-policy override (when `Some`).
+    ///   2. Environment variable `REPLAY_READ_BATCH_SIZE`.
+    ///   3. Built-in default (100).
+    ///
+    /// The runner enforces the invariant `read_batch_size ≥ checkpoint_batch_size`.
+    fn read_batch_size(&self) -> Option<u32> {
+        None
+    }
+
+    /// How many events are processed between cursor persistence calls.  The
+    /// cursor is also written unconditionally at the end of every drain call.
+    ///
+    /// Resolution order (most-specific-first):
+    ///   1. This per-policy override (when `Some`).
+    ///   2. Environment variable `REPLAY_CHECKPOINT_BATCH_SIZE`.
+    ///   3. Built-in default (100).
+    fn checkpoint_batch_size(&self) -> Option<u32> {
+        None
+    }
+
     /// Pure reaction: given an event, return the commands to dispatch.
     ///
     /// Invariant: because delivery is at-least-once, target aggregate command
@@ -152,6 +175,10 @@ pub(crate) trait ErasedPolicy: Send + Sync {
 
     fn max_causation_depth_erased(&self) -> Option<u32>;
 
+    fn read_batch_size_erased(&self) -> Option<u32>;
+
+    fn checkpoint_batch_size_erased(&self) -> Option<u32>;
+
     fn react_erased(&self, raw: &PersistedEvent<serde_json::Value>) -> Vec<Dispatch>;
 }
 
@@ -170,6 +197,14 @@ impl<P: Policy> ErasedPolicy for P {
 
     fn max_causation_depth_erased(&self) -> Option<u32> {
         Policy::max_causation_depth(self)
+    }
+
+    fn read_batch_size_erased(&self) -> Option<u32> {
+        Policy::read_batch_size(self)
+    }
+
+    fn checkpoint_batch_size_erased(&self) -> Option<u32> {
+        Policy::checkpoint_batch_size(self)
     }
 
     fn react_erased(&self, raw: &PersistedEvent<serde_json::Value>) -> Vec<Dispatch> {

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -373,9 +373,12 @@ async fn drain_policy_once(
     max_depth: u32,
 ) -> Result<usize, replay::Error> {
     let name = policy.name().to_string();
-    let feed = read_feed(pool, policy.stream_filter(), *cursor).await?;
+    let checkpoint_size = resolve_checkpoint_batch_size(policy);
+    let read_batch = resolve_read_batch_size(policy, checkpoint_size);
+    let feed = read_feed(pool, policy.stream_filter(), *cursor, read_batch).await?;
 
     let mut executed = 0;
+    let mut events_since_checkpoint = 0u32;
     for (global_position, maybe_raw) in feed {
         if let Some(raw) = maybe_raw {
             let depth = event_causation_depth(&raw);
@@ -409,10 +412,23 @@ async fn drain_policy_once(
                 .await?;
             }
         }
-        // Advance cursor regardless: synthetic rows, depth-limited events, and
-        // normally-processed events all move the checkpoint forward.
-        save_cursor(pool, &name, global_position).await?;
+        // Always track in-memory position.
         *cursor = global_position;
+        events_since_checkpoint += 1;
+
+        // Write the persistent cursor every `checkpoint_size` events so that
+        // a crash re-processes at most `checkpoint_size - 1` events rather
+        // than the full drain batch (skip-safety: the cursor only advances
+        // past events whose reactions are already durably committed).
+        if events_since_checkpoint >= checkpoint_size {
+            save_cursor(pool, &name, global_position).await?;
+            events_since_checkpoint = 0;
+        }
+    }
+
+    // Final checkpoint: flush any events processed since the last periodic save.
+    if events_since_checkpoint > 0 {
+        save_cursor(pool, &name, *cursor).await?;
     }
 
     Ok(executed)
@@ -541,6 +557,7 @@ async fn read_feed(
     pool: &Pool<Postgres>,
     filter: StreamFilter,
     cursor: i64,
+    limit: u32,
 ) -> Result<Vec<(i64, Option<PersistedEvent<Value>>)>, replay::Error> {
     let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
         "SELECT id, data, metadata, stream_id, type, version, created, aggregate_version, \
@@ -549,7 +566,8 @@ async fn read_feed(
     qb.push_bind(cursor);
     qb.push(" AND ");
     PostgresEventStore::add_filters(&mut qb, filter);
-    qb.push(" ORDER BY global_position ASC");
+    qb.push(" ORDER BY global_position ASC LIMIT ");
+    qb.push_bind(limit as i64);
 
     let rows = qb.build().fetch_all(pool).await.map_err(crate::db_error)?;
 
@@ -750,6 +768,18 @@ const DEFAULT_MAX_CAUSATION_DEPTH: u32 = 10;
 /// Environment variable that overrides the built-in depth limit.
 const CAUSATION_DEPTH_ENV_VAR: &str = "REPLAY_MAX_CAUSATION_DEPTH";
 
+/// Built-in default for the number of events fetched per drain call.
+const DEFAULT_READ_BATCH_SIZE: u32 = 100;
+
+/// Built-in default for the number of events between cursor persistence writes.
+const DEFAULT_CHECKPOINT_BATCH_SIZE: u32 = 100;
+
+/// Environment variable that overrides the read-batch default.
+const READ_BATCH_SIZE_ENV_VAR: &str = "REPLAY_READ_BATCH_SIZE";
+
+/// Environment variable that overrides the checkpoint-batch default.
+const CHECKPOINT_BATCH_SIZE_ENV_VAR: &str = "REPLAY_CHECKPOINT_BATCH_SIZE";
+
 /// Resolve the effective causation depth limit for a policy.
 ///
 /// Precedence (most-specific wins):
@@ -771,6 +801,37 @@ fn resolve_max_depth_with_source(policy: &dyn ErasedPolicy) -> (u32, &'static st
         }
     }
     (DEFAULT_MAX_CAUSATION_DEPTH, "built-in default")
+}
+
+/// Resolve the effective checkpoint batch size (events between cursor saves).
+///
+/// Precedence: per-policy override → `REPLAY_CHECKPOINT_BATCH_SIZE` env var → default 100.
+fn resolve_checkpoint_batch_size(policy: &dyn ErasedPolicy) -> u32 {
+    if let Some(n) = policy.checkpoint_batch_size_erased() {
+        return n.max(1);
+    }
+    if let Ok(s) = std::env::var(CHECKPOINT_BATCH_SIZE_ENV_VAR) {
+        if let Ok(n) = s.parse::<u32>() {
+            return n.max(1);
+        }
+    }
+    DEFAULT_CHECKPOINT_BATCH_SIZE
+}
+
+/// Resolve the effective read-batch size (events fetched in a single `read_feed` call).
+///
+/// Precedence: per-policy override → `REPLAY_READ_BATCH_SIZE` env var → default 100.
+/// Enforces the invariant `read_batch_size ≥ checkpoint_batch_size`.
+fn resolve_read_batch_size(policy: &dyn ErasedPolicy, checkpoint_size: u32) -> u32 {
+    let raw = if let Some(n) = policy.read_batch_size_erased() {
+        n.max(1)
+    } else if let Ok(s) = std::env::var(READ_BATCH_SIZE_ENV_VAR) {
+        s.parse::<u32>().unwrap_or(DEFAULT_READ_BATCH_SIZE).max(1)
+    } else {
+        DEFAULT_READ_BATCH_SIZE
+    };
+    // Invariant: read_batch_size ≥ checkpoint_batch_size.
+    raw.max(checkpoint_size)
 }
 
 fn merge_dispatch_metadata(

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -2837,3 +2837,236 @@ async fn policy_business_rule_violation_advances_without_dead_letter_postgres_te
 
     assert_eq!(cursor, 1, "cursor must have advanced past the BRV event");
 }
+
+// ── Batching: read-batch size and checkpoint-batch size (issue #85) ───────────
+
+/// Policy with a custom read-batch size for testing.
+struct SmallBatchPolicy {
+    batch: u32,
+}
+
+impl replay_persistence::Policy for SmallBatchPolicy {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "small_batch_policy"
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Beginning
+    }
+
+    fn read_batch_size(&self) -> Option<u32> {
+        Some(self.batch)
+    }
+
+    fn checkpoint_batch_size(&self) -> Option<u32> {
+        // Match read_batch so the read_batch ≥ checkpoint_batch invariant
+        // does not silently raise the read batch to the default (100).
+        Some(self.batch)
+    }
+
+    fn react(&self, _: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        Vec::new() // observe-only; we care about cursor position, not commands
+    }
+}
+
+/// Policy with explicit batch sizes for checkpoint testing.
+struct CheckpointBatchPolicy {
+    read_batch: u32,
+    checkpoint_batch: u32,
+}
+
+impl replay_persistence::Policy for CheckpointBatchPolicy {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "checkpoint_batch_policy"
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Beginning
+    }
+
+    fn read_batch_size(&self) -> Option<u32> {
+        Some(self.read_batch)
+    }
+
+    fn checkpoint_batch_size(&self) -> Option<u32> {
+        Some(self.checkpoint_batch)
+    }
+
+    fn react(&self, _: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        Vec::new()
+    }
+}
+
+/// `read_batch_size` caps how many events a single drain call fetches.
+///
+/// With 5 events appended and `read_batch_size = 2`, each drain call
+/// processes exactly 2 events (until the last, which gets the remainder).
+/// Three drain calls are required to exhaust all 5 events.
+#[tokio::test]
+async fn policy_read_batch_limits_events_per_drain_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("batch-read-1").unwrap();
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+    let meta = replay::Metadata::default();
+
+    // Append 5 events.
+    for _ in 0..5 {
+        cqrs.execute::<BankAccount>(
+            &account,
+            meta.clone(),
+            BankAccountCommand::Deposit {
+                effective_on: date,
+                amount: 10.0,
+            },
+            &(),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(SmallBatchPolicy { batch: 2 })
+        .build();
+
+    // First drain: processes events at positions 1 and 2.
+    runner.drain().await.expect("drain 1 must succeed");
+    let cursor_1: i64 =
+        sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = 'small_batch_policy'")
+            .fetch_one(&pg_pool)
+            .await
+            .expect("cursor must exist after drain 1");
+    assert_eq!(
+        cursor_1, 2,
+        "first drain (batch=2) must stop at global_position 2"
+    );
+
+    // Second drain: events 3 and 4.
+    runner.drain().await.expect("drain 2 must succeed");
+    let cursor_2: i64 =
+        sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = 'small_batch_policy'")
+            .fetch_one(&pg_pool)
+            .await
+            .expect("cursor must exist after drain 2");
+    assert_eq!(cursor_2, 4, "second drain must stop at global_position 4");
+
+    // Third drain: event 5.
+    runner.drain().await.expect("drain 3 must succeed");
+    let cursor_3: i64 =
+        sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = 'small_batch_policy'")
+            .fetch_one(&pg_pool)
+            .await
+            .expect("cursor must exist after drain 3");
+    assert_eq!(cursor_3, 5, "third drain must reach global_position 5");
+}
+
+/// Crash-recovery / skip-safety: resetting the cursor to an earlier checkpoint
+/// causes only the uncommitted tail to be reprocessed — never a skip.
+///
+/// Scenario:
+///   - 4 events appended.
+///   - `checkpoint_batch_size = 2`: the cursor is written after events 2 and 4
+///     (two checkpoint intervals).
+///   - After a full drain the cursor is at 4.
+///   - Simulate a crash by rolling the cursor back to 2 (the first checkpoint).
+///   - Re-drain: events 3 and 4 are reprocessed (at-least-once; absorbed by
+///     idempotency for dispatching policies).
+///   - Cursor ends at 4 again.
+#[tokio::test]
+async fn policy_checkpoint_batch_crash_recovery_reprocesses_tail_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("checkpoint-batch-1").unwrap();
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+    let meta = replay::Metadata::default();
+
+    for _ in 0..4 {
+        cqrs.execute::<BankAccount>(
+            &account,
+            meta.clone(),
+            BankAccountCommand::Deposit {
+                effective_on: date,
+                amount: 10.0,
+            },
+            &(),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(CheckpointBatchPolicy {
+            read_batch: 4,
+            checkpoint_batch: 2,
+        })
+        .build();
+
+    // Full drain: cursor written at positions 2 and 4 (two checkpoints).
+    runner.drain().await.expect("initial drain must succeed");
+
+    let cursor_after_drain: i64 = sqlx::query_scalar(
+        "SELECT position FROM policy_cursors WHERE name = 'checkpoint_batch_policy'",
+    )
+    .fetch_one(&pg_pool)
+    .await
+    .expect("cursor must exist");
+    assert_eq!(
+        cursor_after_drain, 4,
+        "cursor must be at 4 after full drain"
+    );
+
+    // Simulate crash: roll cursor back to the first checkpoint (position 2),
+    // as if the process died after that checkpoint but before the final one.
+    sqlx::query("UPDATE policy_cursors SET position = 2 WHERE name = 'checkpoint_batch_policy'")
+        .execute(&pg_pool)
+        .await
+        .expect("cursor rollback must succeed");
+
+    // Re-drain from position 2: only events 3 and 4 are reprocessed.
+    runner.drain().await.expect("recovery drain must succeed");
+
+    let cursor_after_recovery: i64 = sqlx::query_scalar(
+        "SELECT position FROM policy_cursors WHERE name = 'checkpoint_batch_policy'",
+    )
+    .fetch_one(&pg_pool)
+    .await
+    .expect("cursor must exist after recovery");
+    assert_eq!(
+        cursor_after_recovery, 4,
+        "cursor must be back at 4 after recovery drain"
+    );
+}


### PR DESCRIPTION
Closes #85

## Summary

Makes policy processing efficient for large backfills via batched reads and batched cursor checkpoints, without sacrificing ordering or skip-safety.

## Key design points (per ADR-0003)

- **A batch is a checkpoint/commit boundary, never a parallelism boundary**: events within a batch are applied strictly sequentially in `global_position` order.
- **One transaction per command execution**: command durability is unchanged.
- **Skip-safety invariant**: the cursor only advances past events whose reactions are already durably committed. A crash re-processes at most `checkpoint_size − 1` events (harmless duplicates, absorbed by idempotency).

## Changes

### `Policy` trait — two new opt-in methods (default `None`)

```rust
fn read_batch_size(&self) -> Option<u32>    // events fetched per drain call
fn checkpoint_batch_size(&self) -> Option<u32>  // cursor write interval
```

### Config cascade (most-specific wins)
| Priority | Read batch | Checkpoint batch |
|---|---|---|
| 1 | `Policy::read_batch_size()` | `Policy::checkpoint_batch_size()` |
| 2 | `REPLAY_READ_BATCH_SIZE` env var | `REPLAY_CHECKPOINT_BATCH_SIZE` env var |
| 3 | built-in default 100 | built-in default 100 |

Invariant: **`read_batch_size ≥ checkpoint_batch_size`** (enforced by resolver).

### `read_feed` — LIMIT pushed to SQL
The feed query now appends `LIMIT ` so the database does the bounding.

### `drain_policy_once` — checkpoint loop
Cursor is written every `checkpoint_size` events during the loop, plus once at the end to flush any remaining events.

## Tests (31 total, all green)

| Test | Scenario |
|---|---|
| `policy_read_batch_limits_events_per_drain` | 5 events, batch=2 → 3 drain calls required; cursor advances 2 per call |
| `policy_checkpoint_batch_crash_recovery_reprocesses_tail` | 4 events, checkpoint=2; cursor rolled back to position 2 (simulated crash) → recovery drain re-processes only events 3–4 |