### PR TITLE
feat(persistence): closure shortcut register_policy_fn + example policy (#87)

### DIFF
--- a/persistence/examples/global_position.rs
+++ b/persistence/examples/global_position.rs
@@ -280,6 +280,50 @@ impl Aggregate for PolicyFeeLedger {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Deposit-fee policy (closure shortcut example)
+//
+// This section shows the low-ceremony `register_policy_fn` path.  The same
+// domain logic is exercised by the Docker-gated integration test
+// `global_position_closure_policy_charges_fee_postgres_test`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Stable cursor key for the deposit-fee policy.
+pub const DEPOSIT_FEE_POLICY_NAME: &str = "deposit_fee";
+
+/// Fee fraction charged on every deposit (1 %).
+pub const DEPOSIT_FEE_RATE: f64 = 0.01;
+
+/// URN of the shared fee ledger aggregate instance.
+pub const DEPOSIT_FEE_LEDGER_ID: &str = "global-fees";
+
+/// Pure reaction for the deposit-fee policy.
+///
+/// Reacts to every [`BankAccountEvent::Deposited`] by charging a 1 % fee to
+/// the shared [`PolicyFeeLedger`].  The `causation_event_id` field in the
+/// command carries the triggering event's identity so the ledger can absorb
+/// duplicate deliveries as no-ops.
+///
+/// Exported so the integration test can pass it directly to
+/// [`PolicyRunnerBuilder::register_policy_fn`] and keep the logic in one place.
+pub fn deposit_fee_react(
+    event: &replay_persistence::PersistedEvent<BankAccountEvent>,
+) -> Vec<replay_persistence::Dispatch> {
+    match &event.data {
+        BankAccountEvent::Deposited { amount } => {
+            let ledger = PolicyFeeLedgerUrn::new(DEPOSIT_FEE_LEDGER_ID).unwrap();
+            vec![replay_persistence::Dispatch::to::<PolicyFeeLedger>(
+                ledger,
+                PolicyFeeLedgerCommand::ChargeFee {
+                    amount: amount * DEPOSIT_FEE_RATE,
+                    causation_event_id: event.id,
+                },
+            )]
+        }
+        _ => Vec::new(),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Cross-aggregate read model: a user's global position
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -79,6 +79,39 @@ where
     }
 }
 
+// ── Closure-based policy adapter ─────────────────────────────────────────────
+
+/// A [`Policy`] backed by a plain closure, created via
+/// [`PolicyRunnerBuilder::register_policy_fn`].
+struct ClosurePolicy<E, F> {
+    name: String,
+    start_at: StartAt,
+    react: F,
+    _phantom: std::marker::PhantomData<E>,
+}
+
+impl<E, F> Policy for ClosurePolicy<E, F>
+where
+    E: replay::Event + 'static,
+    F: Fn(&PersistedEvent<E>) -> Vec<Dispatch> + Send + Sync + 'static,
+{
+    type Event = E;
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn start_at(&self) -> StartAt {
+        self.start_at
+    }
+
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<Dispatch> {
+        (self.react)(event)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 /// Builds a [`PolicyRunner`] by registering aggregate services and policies.
 pub struct PolicyRunnerBuilder {
     cqrs: Cqrs<PostgresEventStore>,
@@ -111,6 +144,45 @@ impl PolicyRunnerBuilder {
     {
         self.policies.push(Arc::new(policy));
         self
+    }
+
+    /// Register a policy using a **closure** instead of a full [`Policy`] impl.
+    ///
+    /// This is the low-ceremony path for simple, single-aggregate reactions where
+    /// writing a dedicated struct + `impl Policy` would be boilerplate:
+    ///
+    /// ```rust,ignore
+    /// runner_builder
+    ///     .register_policy_fn::<BankAccountEvent, _>(
+    ///         "deposit_fee",
+    ///         StartAt::Beginning,
+    ///         |event| match &event.data {
+    ///             BankAccountEvent::Deposited { amount } => vec![
+    ///                 Dispatch::to::<FeeLedger>(ledger_id.clone(), ChargeFee { amount: amount * 0.01 })
+    ///             ],
+    ///             _ => vec![],
+    ///         },
+    ///     )
+    /// ```
+    ///
+    /// The closure runs through the exact same runner machinery as a `Policy` impl:
+    /// causation stamping, failure handling, batching, advisory lock, etc.
+    pub fn register_policy_fn<E, F>(
+        self,
+        name: impl Into<String>,
+        start_at: StartAt,
+        react: F,
+    ) -> Self
+    where
+        E: replay::Event + 'static,
+        F: Fn(&PersistedEvent<E>) -> Vec<Dispatch> + Send + Sync + 'static,
+    {
+        self.register_policy(ClosurePolicy {
+            name: name.into(),
+            start_at,
+            react,
+            _phantom: std::marker::PhantomData,
+        })
     }
 
     pub fn build(self) -> PolicyRunner {

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -3070,3 +3070,101 @@ async fn policy_checkpoint_batch_crash_recovery_reprocesses_tail_postgres_test()
         "cursor must be back at 4 after recovery drain"
     );
 }
+
+// ── Closure shortcut: register_policy_fn (issue #87) ─────────────────────────
+
+/// `register_policy_fn` wires the deposit-fee reaction (defined in the example)
+/// through the same runner machinery as a full `impl Policy`.
+///
+/// Scenario:
+///   - User registers; opens a BankAccount.
+///   - A deposit of $100 is made.
+///   - The closure policy (defined in `global_position.rs`) reacts to the
+///     `Deposited` event and dispatches `ChargeFee { amount: 1.0 }` to the
+///     `PolicyFeeLedger`.
+///   - After drain: a `FeeCharged` event exists on the ledger stream.
+///   - Drain is idempotent: running it again produces no additional fees.
+#[tokio::test]
+async fn global_position_closure_policy_charges_deposit_fee_postgres_test() {
+    use global_position::{
+        BankAccount, BankAccountCommand, BankAccountEvent, BankAccountUrn, PolicyFeeLedger,
+        PolicyFeeLedgerUrn, DEPOSIT_FEE_LEDGER_ID, DEPOSIT_FEE_POLICY_NAME, DEPOSIT_FEE_RATE,
+    };
+
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("closure-test-1").unwrap();
+
+    // Deposit $100 into the account.
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::OpenAccount {
+            owner: global_position::UserUrn::new("alice").unwrap(),
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let deposit_amount = 100.0_f64;
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            amount: deposit_amount,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_services::<PolicyFeeLedger>(())
+        .register_policy_fn::<BankAccountEvent, _>(
+            DEPOSIT_FEE_POLICY_NAME,
+            replay_persistence::StartAt::Beginning,
+            global_position::deposit_fee_react,
+        )
+        .build();
+
+    // First drain: reacts to the Deposited event and charges the fee.
+    let dispatched = runner.drain().await.expect("first drain must succeed");
+    assert_eq!(dispatched, 1, "one FeeCharged command must be dispatched");
+
+    // The fee ledger must have a FeeCharged event for the expected amount.
+    let expected_fee = deposit_amount * DEPOSIT_FEE_RATE;
+    let ledger_urn = PolicyFeeLedgerUrn::new(DEPOSIT_FEE_LEDGER_ID).unwrap();
+    let ledger = cqrs
+        .fetch_aggregate::<PolicyFeeLedger>(&ledger_urn)
+        .await
+        .expect("fee ledger must be fetchable");
+    assert!(
+        (ledger.balance - (-expected_fee)).abs() < 1e-9,
+        "fee ledger balance must be -{expected_fee:.2}, got {:.2}",
+        ledger.balance
+    );
+
+    // Second drain: idempotent — the causation guard absorbs the duplicate.
+    let dispatched_again = runner.drain().await.expect("second drain must succeed");
+    assert_eq!(
+        dispatched_again, 0,
+        "second drain must dispatch nothing (cursor already advanced)"
+    );
+}


### PR DESCRIPTION
Closes #87

## Summary

Lowers the authoring ceremony for simple single-aggregate reactions and aligns the `global_position` example with the test suite.

## Changes

### `register_policy_fn` — closure shortcut on `PolicyRunnerBuilder`

```rust
runner_builder
    .register_policy_fn::<BankAccountEvent, _>(
        "deposit_fee",
        StartAt::Beginning,
        |event| match &event.data {
            BankAccountEvent::Deposited { amount } => vec![
                Dispatch::to::<FeeLedger>(ledger_id, ChargeFee { amount: amount * 0.01 })
            ],
            _ => vec![],
        },
    )
```

Backed by a private `ClosurePolicy<E, F>` struct that implements `Policy`. The closure runs through the same runner machinery as a full trait impl: causation stamping, failure handling, batching, advisory-lock leadership, etc.

### `global_position` example — deposit-fee policy section

The example now covers all three reader patterns side by side:

| Pattern | Type |
|---|---|
| Live query | `GlobalPositionQuery` |
| Inline projection | `GlobalPositionProjection` |
| **Policy (closure shortcut)** | **`deposit_fee_react` + `register_policy_fn`** |

Exported helpers (reused by the integration test to keep logic in one place):
- `DEPOSIT_FEE_POLICY_NAME` — stable cursor key
- `DEPOSIT_FEE_RATE` — 1 % fee fraction
- `DEPOSIT_FEE_LEDGER_ID` — shared ledger stream id
- `deposit_fee_react(event)` — the pure reaction closure

## Tests (32 total, all green)

`global_position_closure_policy_charges_deposit_fee`:
- Deposit $100 → closure policy dispatches `ChargeFee { amount: 1.0 }` to `PolicyFeeLedger`
- Drain 1: 1 command executed; ledger balance = −$1.00
- Drain 2: 0 commands (cursor already advanced; causation guard absorbs duplicate)