### PR TITLE
feat(persistence): LISTEN/NOTIFY latency optimisation for policy runner (#86)

### DIFF
--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -509,6 +509,18 @@ impl EventStore for PostgresEventStore {
         }
 
         transaction.commit().await.map_err(crate::db_error)?;
+
+        // Best-effort NOTIFY: wake any waiting policy tasks immediately so they
+        // react without waiting for the next poll interval.  Errors are silently
+        // swallowed — polling remains the correctness baseline and a missed
+        // notification is caught on the next interval.
+        if !domain_events.is_empty() {
+            let _ = sqlx::query("SELECT pg_notify('replay_events', $1)")
+                .bind(&stream_type)
+                .execute(&self.pool)
+                .await;
+        }
+
         Ok(())
     }
 

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -515,7 +515,8 @@ impl EventStore for PostgresEventStore {
         // swallowed — polling remains the correctness baseline and a missed
         // notification is caught on the next interval.
         if !domain_events.is_empty() {
-            let _ = sqlx::query("SELECT pg_notify('replay_events', $1)")
+            let _ = sqlx::query("SELECT pg_notify($1, $2)")
+                .bind(crate::REPLAY_NOTIFY_CHANNEL)
                 .bind(&stream_type)
                 .execute(&self.pool)
                 .await;

--- a/persistence/src/lib.rs
+++ b/persistence/src/lib.rs
@@ -18,7 +18,9 @@ pub use infrastructure::{InMemoryEventStore, PostgresEventStore, PostgresInlineP
 pub use inline_projection::InlineProjection;
 pub use persisted_event::PersistedEvent;
 pub use policy::{Dispatch, Policy, StartAt};
-pub use policy_runner::{PolicyRunner, PolicyRunnerBuilder, PolicyRunnerDaemon};
+pub use policy_runner::{
+    PolicyRunner, PolicyRunnerBuilder, PolicyRunnerDaemon, REPLAY_NOTIFY_CHANNEL,
+};
 pub use query::Query;
 pub use store::EventStore;
 

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -79,6 +79,11 @@ where
     }
 }
 
+/// Postgres NOTIFY channel used to wake waiting policy tasks after an append.
+/// Policy tasks LISTEN on this channel; `PostgresEventStore::store_events`
+/// fires a NOTIFY on it after every successful commit.
+pub const REPLAY_NOTIFY_CHANNEL: &str = "replay_events";
+
 // ── Closure-based policy adapter ─────────────────────────────────────────────
 
 /// A [`Policy`] backed by a plain closure, created via
@@ -118,6 +123,7 @@ pub struct PolicyRunnerBuilder {
     pool: Pool<Postgres>,
     policies: Vec<Arc<dyn ErasedPolicy>>,
     executors: HashMap<TypeId, Arc<dyn AggregateExecutor>>,
+    notifications: bool,
 }
 
 impl PolicyRunnerBuilder {
@@ -167,6 +173,16 @@ impl PolicyRunnerBuilder {
     ///
     /// The closure runs through the exact same runner machinery as a `Policy` impl:
     /// causation stamping, failure handling, batching, advisory lock, etc.
+    /// Disable the `LISTEN/NOTIFY` latency optimisation; the daemon will poll
+    /// on the fixed interval only.
+    ///
+    /// Useful in environments where `pg_notify` is unavailable or for
+    /// deterministic testing without a NOTIFY wakeup.
+    pub fn without_notifications(mut self) -> Self {
+        self.notifications = false;
+        self
+    }
+
     pub fn register_policy_fn<E, F>(
         self,
         name: impl Into<String>,
@@ -191,6 +207,7 @@ impl PolicyRunnerBuilder {
             pool: self.pool,
             policies: self.policies,
             executors: self.executors,
+            notifications: self.notifications,
         }
     }
 }
@@ -201,6 +218,7 @@ pub struct PolicyRunner {
     pool: Pool<Postgres>,
     policies: Vec<Arc<dyn ErasedPolicy>>,
     executors: HashMap<TypeId, Arc<dyn AggregateExecutor>>,
+    notifications: bool,
 }
 
 /// Handle for background policy tasks spawned by [`PolicyRunner::start_polling`].
@@ -228,6 +246,7 @@ impl PolicyRunner {
             pool,
             policies: Vec::new(),
             executors: HashMap::new(),
+            notifications: true,
         }
     }
 
@@ -271,6 +290,7 @@ impl PolicyRunner {
             let cqrs = self.cqrs.clone();
             let pool = self.pool.clone();
             let executors = self.executors.clone();
+            let notifications = self.notifications;
             let mut policy_shutdown_rx = shutdown_rx.clone();
 
             tasks.push(tokio::spawn(async move {
@@ -358,6 +378,42 @@ impl PolicyRunner {
                         }
                     };
 
+                    // Optionally subscribe to NOTIFY wakeups so the loop reacts to
+                    // new appends immediately rather than waiting out the poll interval.
+                    // Errors here are non-fatal: the task falls back to pure polling.
+                    let mut listener: Option<sqlx::postgres::PgListener> = if notifications {
+                        match sqlx::postgres::PgListener::connect_with(&pool).await {
+                            Ok(mut l) => match l.listen(REPLAY_NOTIFY_CHANNEL).await {
+                                Ok(()) => {
+                                    tracing::debug!(
+                                        policy = %name,
+                                        channel = REPLAY_NOTIFY_CHANNEL,
+                                        "LISTEN active; will wake on NOTIFY"
+                                    );
+                                    Some(l)
+                                }
+                                Err(error) => {
+                                    tracing::warn!(
+                                        policy = %name,
+                                        error = %error,
+                                        "LISTEN setup failed; falling back to polling"
+                                    );
+                                    None
+                                }
+                            },
+                            Err(error) => {
+                                tracing::warn!(
+                                    policy = %name,
+                                    error = %error,
+                                    "PgListener connect failed; falling back to polling"
+                                );
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
                     // Leadership polling loop.
                     let max_depth = resolve_max_depth(policy.as_ref());
                     loop {
@@ -385,13 +441,38 @@ impl PolicyRunner {
                             }
                         }
 
-                        tokio::select! {
-                            changed = policy_shutdown_rx.changed() => {
-                                if changed.is_err() || *policy_shutdown_rx.borrow() {
-                                    break;
+                        // Wait for the next wakeup: NOTIFY (if enabled), poll
+                        // timeout, or shutdown signal — whichever fires first.
+                        if let Some(ref mut l) = listener {
+                            tokio::select! {
+                                changed = policy_shutdown_rx.changed() => {
+                                    if changed.is_err() || *policy_shutdown_rx.borrow() {
+                                        break;
+                                    }
+                                }
+                                _ = tokio::time::sleep(interval) => {}
+                                res = l.recv() => {
+                                    if let Err(error) = res {
+                                        tracing::warn!(
+                                            policy = %name,
+                                            error = %error,
+                                            "PgListener recv error; falling back to polling"
+                                        );
+                                        listener = None;
+                                    }
+                                    // Notification received or listener dropped:
+                                    // proceed to drain immediately.
                                 }
                             }
-                            _ = tokio::time::sleep(interval) => {}
+                        } else {
+                            tokio::select! {
+                                changed = policy_shutdown_rx.changed() => {
+                                    if changed.is_err() || *policy_shutdown_rx.borrow() {
+                                        break;
+                                    }
+                                }
+                                _ = tokio::time::sleep(interval) => {}
+                            }
                         }
                     }
 

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -152,6 +152,16 @@ impl PolicyRunnerBuilder {
         self
     }
 
+    /// Disable the `LISTEN/NOTIFY` latency optimisation; the daemon will use
+    /// the fixed poll interval only, with no `PgListener` connection.
+    ///
+    /// Useful in environments where `pg_notify` is unavailable or for
+    /// deterministic testing without a NOTIFY wakeup.
+    pub fn without_notifications(mut self) -> Self {
+        self.notifications = false;
+        self
+    }
+
     /// Register a policy using a **closure** instead of a full [`Policy`] impl.
     ///
     /// This is the low-ceremony path for simple, single-aggregate reactions where
@@ -173,16 +183,6 @@ impl PolicyRunnerBuilder {
     ///
     /// The closure runs through the exact same runner machinery as a `Policy` impl:
     /// causation stamping, failure handling, batching, advisory lock, etc.
-    /// Disable the `LISTEN/NOTIFY` latency optimisation; the daemon will poll
-    /// on the fixed interval only.
-    ///
-    /// Useful in environments where `pg_notify` is unavailable or for
-    /// deterministic testing without a NOTIFY wakeup.
-    pub fn without_notifications(mut self) -> Self {
-        self.notifications = false;
-        self
-    }
-
     pub fn register_policy_fn<E, F>(
         self,
         name: impl Into<String>,

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -3168,3 +3168,141 @@ async fn global_position_closure_policy_charges_deposit_fee_postgres_test() {
         "second drain must dispatch nothing (cursor already advanced)"
     );
 }
+
+// ── LISTEN/NOTIFY latency optimisation (issue #86) ───────────────────────────
+
+/// With NOTIFY enabled the daemon wakes immediately on an append, well before
+/// the poll interval would fire.
+///
+/// The test uses a 30 s poll interval but expects a reaction within 5 s — if
+/// NOTIFY is working the daemon wakes as soon as `store_events` fires the
+/// `pg_notify('replay_events', ...)` after committing.
+#[tokio::test]
+async fn policy_notify_wakes_daemon_before_poll_interval_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("notify-wake-1").unwrap();
+
+    // Start the daemon with NOTIFY enabled (default) and a very long poll interval
+    // so that any reaction *before* 5 s must have been triggered by NOTIFY.
+    let runner = std::sync::Arc::new(
+        replay_persistence::PolicyRunner::builder(cqrs.clone())
+            .register_services::<BankAccount>(())
+            .register_policy(WithdrawFeePolicyStartAtBeginning { fee: 5.0 })
+            .build(),
+    );
+    let daemon = runner
+        .clone()
+        .start_polling(std::time::Duration::from_secs(30));
+
+    // Allow the daemon task to start and acquire the advisory lock before appending.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Wait up to 5 s; the NOTIFY wakeup should trigger within ~100 ms.
+    let mut reacted = false;
+    for _ in 0..100 {
+        let state = cqrs.fetch_aggregate::<BankAccount>(&account).await.unwrap();
+        if (state.balance - 95.0).abs() < f64::EPSILON {
+            reacted = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    daemon.shutdown().await;
+
+    assert!(
+        reacted,
+        "policy must react via NOTIFY before the 30 s poll interval fires"
+    );
+}
+
+/// With notifications disabled the daemon falls back to pure polling and still
+/// reacts correctly.
+#[tokio::test]
+async fn policy_daemon_reacts_without_notify_via_polling_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("no-notify-1").unwrap();
+
+    let runner = std::sync::Arc::new(
+        replay_persistence::PolicyRunner::builder(cqrs.clone())
+            .register_services::<BankAccount>(())
+            .register_policy(WithdrawFeePolicyStartAtBeginning { fee: 5.0 })
+            // Disable NOTIFY: must still react via the polling interval.
+            .without_notifications()
+            .build(),
+    );
+    let daemon = runner
+        .clone()
+        .start_polling(std::time::Duration::from_millis(50));
+
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let mut reacted = false;
+    for _ in 0..40 {
+        let state = cqrs.fetch_aggregate::<BankAccount>(&account).await.unwrap();
+        if (state.balance - 95.0).abs() < f64::EPSILON {
+            reacted = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    daemon.shutdown().await;
+
+    assert!(
+        reacted,
+        "policy must react via polling even when NOTIFY is disabled"
+    );
+}


### PR DESCRIPTION
Closes #86

## Summary

Reduces policy reaction latency from one poll interval to near-zero by adding a Postgres `LISTEN/NOTIFY` wakeup on top of the existing polling baseline.

## Design (per ADR-0003)

- **NOTIFY is a best-effort hint, not a correctness guarantee.** Polling remains the source of truth; a missed notification is caught on the next interval.
- **The optimisation is transparent and on by default.** Existing code using `start_polling` gets NOTIFY wakeups without any change.
- **Can be disabled** via `PolicyRunnerBuilder::without_notifications()` for environments where `pg_notify` is unavailable or for deterministic tests.
- **Listener errors are non-fatal.** If the `PgListener` connection drops during a leadership tenure, the task logs a warning and falls back to pure polling for that tenure.

## Changes

### `PostgresEventStore::store_events`
After each successful `transaction.commit()`, fires:
```sql
SELECT pg_notify('replay_events', $stream_type)
```
Errors are swallowed (fire-and-forget).

### `PolicyRunner` / `PolicyRunnerBuilder`
- `pub const REPLAY_NOTIFY_CHANNEL: &str = "replay_events"`
- `notifications: bool` field (default `true`)
- `PolicyRunnerBuilder::without_notifications()` → opt out

### `start_polling` — wakeup select
When notifications are enabled, each policy task creates a `PgListener` after acquiring the advisory lock and subscribes to `REPLAY_NOTIFY_CHANNEL`. The wait step changes from:
```
sleep(interval) | shutdown
```
to:
```
sleep(interval) | listener.recv() | shutdown
```

## Tests (34 total, all green)

| Test | Scenario |
|---|---|
| `policy_notify_wakes_daemon_before_poll_interval` | 30 s poll, NOTIFY on → reaction within 5 s (NOTIFY fires ~100 ms after commit) |
| `policy_daemon_reacts_without_notify_via_polling` | NOTIFY disabled → 50 ms poll → reaction still occurs correctly |