### PR TITLE
feat(persistence): at-least-once idempotency contract with duplicate-delivery proof (#80)

### DIFF
--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -2162,6 +2162,114 @@ async fn policy_duplicate_delivery_is_absorbed_by_causation_guard_postgres_test(
     assert_eq!(fee_event_count, 1);
 }
 
+/// Duplicate delivery proof using the example causation-guard recipe directly.
+///
+/// Uses the exact `PolicyFeeLedger` aggregate and `deposit_fee_react` function
+/// exported from `global_position.rs` — the copy-pasteable recipe documented for
+/// policy-target aggregates.  Proves the example recipe handles at-least-once
+/// delivery correctly: a re-delivered triggering event produces no second fee charge.
+#[tokio::test]
+async fn policy_duplicate_delivery_example_recipe_postgres_test() {
+    use global_position::{
+        BankAccount, BankAccountCommand, BankAccountUrn as GpAccountUrn, PolicyFeeLedger,
+        PolicyFeeLedgerCommand, PolicyFeeLedgerUrn, DEPOSIT_FEE_LEDGER_ID, DEPOSIT_FEE_POLICY_NAME,
+        DEPOSIT_FEE_RATE,
+    };
+
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+
+    // Open the fee ledger with a known starting balance using the Credit command.
+    let ledger_id = PolicyFeeLedgerUrn::new(DEPOSIT_FEE_LEDGER_ID).unwrap();
+    cqrs.execute::<PolicyFeeLedger>(
+        &ledger_id,
+        replay::Metadata::default(),
+        PolicyFeeLedgerCommand::Credit { amount: 1_000.0 },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Register the deposit-fee reaction using the exported example function directly.
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<PolicyFeeLedger>(())
+        .register_policy_fn::<global_position::BankAccountEvent, _>(
+            DEPOSIT_FEE_POLICY_NAME,
+            replay_persistence::StartAt::Now,
+            global_position::deposit_fee_react,
+        )
+        .build();
+
+    // Bootstrap cursor at current head (after ledger open, before any deposit).
+    let n: usize = runner.drain().await.unwrap();
+    assert_eq!(n, 0);
+
+    // Make a deposit to trigger the policy: 1 000 @ 1 % = 10 fee.
+    let source = GpAccountUrn::new("dup-example-src").unwrap();
+    cqrs.execute::<BankAccount>(
+        &source,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit { amount: 1_000.0 },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // First delivery: one fee charged.
+    let n: usize = runner.drain().await.unwrap();
+    assert_eq!(n, 1);
+    let after_first = cqrs
+        .fetch_aggregate::<PolicyFeeLedger>(&ledger_id)
+        .await
+        .unwrap();
+    let expected_balance = 1_000.0 - (1_000.0 * DEPOSIT_FEE_RATE);
+    assert_eq!(after_first.balance, expected_balance);
+
+    // Simulate redelivery by rewinding the cursor behind the deposit event.
+    sqlx::query("UPDATE policy_cursors SET position = 1 WHERE name = $1")
+        .bind(DEPOSIT_FEE_POLICY_NAME)
+        .execute(&pg_pool)
+        .await
+        .expect("cursor rewind must succeed");
+
+    // Second delivery: causation guard in PolicyFeeLedger absorbs the duplicate.
+    let n: usize = runner.drain().await.unwrap();
+    assert_eq!(n, 1);
+    let after_second = cqrs
+        .fetch_aggregate::<PolicyFeeLedger>(&ledger_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        after_second.balance, expected_balance,
+        "causation guard must prevent double-charging on redelivery"
+    );
+
+    // Exactly one FeeCharged event — no duplicate was persisted.
+    let fee_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE stream_id = $1 AND type = $2")
+            .bind(Into::<Urn>::into(ledger_id).to_string())
+            .bind("FeeCharged")
+            .fetch_one(&pg_pool)
+            .await
+            .expect("fee event count query must succeed");
+    assert_eq!(fee_count, 1);
+}
+
 // ── Compaction feed (issue #81) ───────────────────────────────────────────────
 
 /// Policy correctly walks the true log across a compaction boundary.

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -2240,8 +2240,22 @@ async fn policy_duplicate_delivery_example_recipe_postgres_test() {
     let expected_balance = 1_000.0 - (1_000.0 * DEPOSIT_FEE_RATE);
     assert_eq!(after_first.balance, expected_balance);
 
-    // Simulate redelivery by rewinding the cursor behind the deposit event.
-    sqlx::query("UPDATE policy_cursors SET position = 1 WHERE name = $1")
+    // Simulate redelivery by rewinding the cursor to just before the deposit
+    // event. Query the actual global_position so the rewind target is stable
+    // regardless of how many events earlier setup may emit.
+    let deposit_gp: i64 = sqlx::query_scalar(
+        "SELECT global_position FROM events \
+         WHERE stream_id = $1 AND type = $2 \
+         ORDER BY global_position ASC LIMIT 1",
+    )
+    .bind(Into::<Urn>::into(source.clone()).to_string())
+    .bind("Deposited")
+    .fetch_one(&pg_pool)
+    .await
+    .expect("deposit event must exist in the global feed");
+
+    sqlx::query("UPDATE policy_cursors SET position = $1 WHERE name = $2")
+        .bind(deposit_gp - 1)
         .bind(DEPOSIT_FEE_POLICY_NAME)
         .execute(&pg_pool)
         .await


### PR DESCRIPTION
Closes #80

## What this adds

A new integration test **** that closes the loop on all four acceptance criteria for issue #80 by using the *exact same types* exported from the example:

| Acceptance criterion | Satisfied by |
|---|---|
| Policy-emitted events carry causation metadata | `causation_metadata()` in `policy_runner.rs` (already on main) |
| Causation-guard recipe in the example aggregate | `PolicyFeeLedger` + `deposit_fee_react` in `global_position.rs` (already on main) |
| `Policy::react` docs lead with idempotency invariant | `policy.rs` trait doc (already on main) |
| Duplicate-delivery Postgres test | **this PR** — new test `policy_duplicate_delivery_example_recipe_postgres_test` |

### Test scenario

1. Open a `PolicyFeeLedger` (the example recipe aggregate) with a 1 000 credit.
2. Register `deposit_fee_react` (the exported example reaction fn) via `register_policy_fn` with `StartAt::Now`.
3. Deposit 1 000 to a `BankAccount` → policy fires → ledger charged 1 % (10.0).
4. Rewind cursor to simulate a crash-before-checkpoint redelivery.
5. Second drain re-delivers the same deposit event; `PolicyFeeLedger`'s causation guard returns no events; balance unchanged; exactly **one** `FeeCharged` in the log.

This is a direct executable proof that the example recipe handles at-least-once delivery correctly.