### PR TITLE
chore(deps): remove unused deps, bump minor versions, upgrade sqlx 0.8→0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ readme = "README.md"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_with = "3.20.0"
-serde_json = "1.0.149"
+serde_with = "3.21.0"
+serde_json = "1.0.150"
 
 urn = { version = "0.7.0", features = ["serde"] }
-uuid = { version = "1.23.1", features = [
+uuid = { version = "1.23.2", features = [
   "v4",
   "serde",
 ], default-features = false }
@@ -28,7 +28,7 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2.0.18"
 anyhow = "1.0.102"
 
-sqlx = { version = "0.8.6", features = [
+sqlx = { version = "0.9.0", features = [
   "runtime-tokio",
   "uuid",
   "chrono",
@@ -45,7 +45,6 @@ moka = { version = "0.12.15", features = ["future"] }
 tracing = "0.1.44"
 
 # Dev dependencies
-log = "0.4.29"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tracing-test = "0.2"
 tokio-test = "0.4.5"
@@ -53,12 +52,11 @@ testcontainers-modules = { version = "0.15.0", features = [
   "postgres",
   "blocking",
 ] }
-dotenvy = "0.15.7"
 
 # Proc-macro dependencies
-proc-macro2 = "1.0.105"
+proc-macro2 = "1.0.106"
 syn = { version = "2.0.117", features = ["visit"] }
 quote = "1.0.45"
 
 # test dependencies
-wasm-bindgen-test = "0.3.68"
+wasm-bindgen-test = "0.3.73"

--- a/es/Cargo.toml
+++ b/es/Cargo.toml
@@ -28,7 +28,6 @@ futures = { workspace = true }
 [dev-dependencies]
 tracing-test = { workspace = true }
 uuid = { workspace = true }
-async-trait = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true }

--- a/persistence/Cargo.toml
+++ b/persistence/Cargo.toml
@@ -43,8 +43,6 @@ tracing = { workspace = true }
 moka = { workspace = true }
 
 [dev-dependencies]
-log = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio-test = { workspace = true }
 testcontainers-modules = { workspace = true }
-dotenvy = { workspace = true }


### PR DESCRIPTION
## Summary

Dependency hygiene pass before the v0.5.0 publish.

### Removed unused dependencies

| Dep | Location | Reason |
|-----|----------|--------|
| `log` | `persistence` dev-deps | declared but never called (`log::` not found anywhere) |
| `dotenvy` | `persistence` dev-deps | declared but never called |
| `async-trait` | `es` dev-deps | tests use native AFIT (`async fn` in trait); `#[async_trait]` never appears in test code |

### Bumped pinned workspace versions

| Dep | Before | After |
|-----|--------|-------|
| `serde_with` | 3.20.0 | 3.21.0 |
| `serde_json` | 1.0.149 | 1.0.150 |
| `uuid` | 1.23.1 | 1.23.2 |
| `proc-macro2` | 1.0.105 | 1.0.106 |
| `wasm-bindgen-test` | 0.3.68 | 0.3.73 |

### sqlx 0.8.6 → 0.9.0

Key breaking changes in 0.9.0 and why they do **not** affect this codebase:

- **`SqlSafeStr`** — `query*()` now requires `&'static str` or `AssertSqlSafe`. Every `sqlx::query()` call in this repo uses a string literal; no dynamic queries built with `format!()`.
- **Deprecated runtime features removed** — we already use `runtime-tokio` (not the old `runtime-tokio-native-tls`).
- **`PgHasArrayType` auto-derived for newtypes** — no manual `PgHasArrayType` impls exist.
- **`Migrate` trait changes** — only `sqlx::migrate!()` macro is used, not the trait directly.
- **MSRV bump to 1.94** — stable toolchain updated to 1.96.0.

### Cargo.lock transitive updates (via `cargo update`)
chrono, bitflags, mio, hyper, prost, zerocopy, and ~20 other transitive deps updated to latest compatible versions.