### PR TITLE
feat(es): add stream-first handle_stream to Aggregate with one-directional defaults

### DIFF
--- a/docs/adr/0005-stream-first-event-emission.md
+++ b/docs/adr/0005-stream-first-event-emission.md
@@ -1,0 +1,87 @@
+# Commands emit events as a stream, the store ingests it under one transaction
+
+**Status:** accepted
+
+Reads and writes were asymmetric. The read side is lazy —
+[`EventStore::stream_events`](../../persistence/src/store.rs) returns an
+`impl TryStream` and folds events with bounded memory. The write side was eager:
+[`Aggregate::handle`](../../es/src/aggregate.rs) returns `Vec<Event>`, and
+[`Cqrs::execute`](../../persistence/src/cqrs.rs) hands that whole `Vec` to
+`store_events(&[Event])`. A command that emits a very large batch (the motivating
+case: a bulk import producing ~160k row events into a single stream) must
+therefore materialise every event in memory at once, even though the aggregate
+itself only needs to fold tiny bounded state (e.g. counters).
+
+The goal is **stream-first**: the canonical event path is a stream, and arrays
+become a convenience layered on top — *without breaking the existing
+`handle -> Vec` contract* that every current aggregate depends on.
+
+## Decision
+
+**Producer (the `es` crate).** `Aggregate` gains `handle_stream`, returning an
+**owned** stream of raw domain events:
+
+```text
+async fn handle_stream(&self, cmd, services)
+    -> Result<impl Stream<Item = Result<Self::Event, Error>>, Self::Error>
+```
+
+- `handle` gets a default returning `Ok(vec![])`; `handle_stream` gets a default
+  that wraps `handle` via `stream::iter`. The defaults point in **one direction**
+  (`handle_stream → handle`), so there is no mutual recursion. Existing aggregates
+  implement `handle` and get streaming for free; bulk aggregates implement
+  `handle_stream` and never build a `Vec`.
+- The returned stream is **owned** and does not borrow the aggregate, so the
+  orchestrator can hold `&mut aggregate` to fold each event as it streams past
+  (apply-as-you-stream). The producer reads its external source (a file/reader),
+  not evolving aggregate state — it yields **raw `Self::Event`**, before any id or
+  version exists.
+- Both WASM cfg arms of `Aggregate` carry the two defaulted methods: `+ Send` on
+  the future *and* the inner stream in the native arm, neither under
+  `target_arch = "wasm32"`.
+
+**Consumption (the native `persistence` crate).** `Cqrs::execute` calls **only**
+`handle_stream` ("stream-first internally") and still returns the folded
+aggregate. The store owns the loop and the transaction; the orchestrator injects
+a sink:
+
+- `EventStore::store_events_stream` becomes the **canonical** method: it drives a
+  `TryStream<Ok = S::Event>` into storage under **one transaction**, notifying an
+  `EventSink<E>` per appended event. `store_events(&[Event])` becomes a default
+  that wraps the slice in `stream::iter` with a `NoSink`. Both the Postgres and
+  in-memory backends implement only the streaming method; in-memory honours the
+  same all-or-nothing semantics.
+- `EventSink<E>` is a named trait — `fn on_event(&mut self, &PersistedEvent<E>)` —
+  with a blanket impl for `FnMut(&PersistedEvent<E>)` (so closures work
+  everywhere) and a provided `NoSink`. The sink is an **infallible observer**:
+  `apply` is sync and side-effect-free by definition, so the sink can never abort.
+  Atomicity is owned **solely** by the producer yielding `Err` and by database
+  errors. `Cqrs`'s sink is simply `|e| aggregate.apply(e.data.clone())`.
+- Because `PersistedEvent` lives only in `persistence`, the whole sink/store
+  machinery is **native-only, single-arm**; only `handle_stream` in `es` needs the
+  dual-cfg treatment.
+
+**Optimistic concurrency.** A streamed append checks `expected_version`
+**once at the head** of the transaction and then appends the whole stream without
+re-checking. The `SELECT ... FOR UPDATE` on the stream row already serialises
+concurrent writers for the transaction's duration, so no mid-batch race is
+possible. This also corrects a latent bug: the previous per-event check compared
+the same `expected_version` against a stream version that increments on every
+append, so any multi-event batch with `expected_version` set would have failed on
+the second event.
+
+## Consequences
+
+- A large atomic append now holds **one long-running write transaction** for the
+  duration of the import (locks held, WAL retained). This is the deliberate price
+  of all-or-nothing semantics with bounded memory; chunked/resumable commits were
+  rejected for this iteration.
+- An aggregate that implements **neither** `handle` nor `handle_stream` compiles
+  and silently swallows commands (empty stream). Mitigated by documentation
+  ("implement at least one") rather than added machinery.
+- `expected_version` now means "the stream head when my decision began," checked
+  once — a small but real change to the append concurrency contract.
+- Per-event metadata is intentionally **not** supported: one batch-level
+  `Metadata` is stamped on every event in the append, as before. Per-event
+  provenance belongs in the event payload and can be added later without breaking
+  this design.

--- a/es/src/aggregate.rs
+++ b/es/src/aggregate.rs
@@ -1,8 +1,17 @@
 use std::future::Future;
 
-use futures::TryStream;
+use futures::{StreamExt, TryStream};
 
 use crate::{Error, EventStream};
+
+/// The result of [`Aggregate::handle_stream`]: an owned, boxed (`Send`) event stream or an error.
+#[cfg(not(target_arch = "wasm32"))]
+type HandleStreamResult<E, Err> = Result<futures::stream::BoxStream<'static, Result<E, Err>>, Err>;
+
+/// The result of [`Aggregate::handle_stream`]: an owned, boxed (single-threaded) event stream or an error.
+#[cfg(target_arch = "wasm32")]
+type HandleStreamResult<E, Err> =
+    Result<futures::stream::LocalBoxStream<'static, Result<E, Err>>, Err>;
 
 /// An aggregate is a domain-driven design pattern that allows you to model a domain entity as a sequence of events.
 ///
@@ -25,9 +34,18 @@ use crate::{Error, EventStream};
 ///
 /// # Methods
 /// - `handle`: Validates and processes a command, returning the resulting events or an error.
+/// - `handle_stream`: Stream-first variant of `handle` that yields events lazily instead of
+///   buffering them in a `Vec`.  Use this for commands that may emit very large batches.
 /// - `handle_and_apply`: Processes a command and, if successful, applies the resulting events to the aggregate instance. This is a convenience method for typical aggregate workflows where you want to both validate and mutate state in one step.
 /// - `with_id`: Creates a new aggregate instance with the given id (recommended constructor).
 /// - `id`: Returns the aggregate's identifier (URN).
+///
+/// # `handle` vs `handle_stream`
+/// Implement **at least one** of `handle` / `handle_stream`.  They have one-directional
+/// defaults: `handle` defaults to producing no events, and `handle_stream` defaults to
+/// wrapping `handle`'s `Vec` in a stream.  Implementing only `handle` gives you a streaming
+/// path for free; implementing only `handle_stream` lets a bulk producer avoid ever building
+/// a `Vec`.  Implementing neither compiles but silently emits no events.
 #[cfg(not(target_arch = "wasm32"))]
 pub trait Aggregate: Sync + Send + EventStream {
     type Command: Send;
@@ -39,7 +57,34 @@ pub trait Aggregate: Sync + Send + EventStream {
         &self,
         command: Self::Command,
         services: &Self::Services,
-    ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send {
+        let _ = (command, services);
+        async { Ok(Vec::new()) }
+    }
+
+    /// Stream-first variant of [`handle`](Aggregate::handle).
+    ///
+    /// Returns an **owned** stream of `Result<Self::Event, Self::Error>` that does not borrow
+    /// the aggregate, so a caller can fold each event into the same aggregate as it streams.
+    /// The default wraps [`handle`](Aggregate::handle), so existing aggregates get a streaming
+    /// path for free.
+    ///
+    /// The stream is boxed so that its type does not capture the `&self` borrow; this keeps it
+    /// `'static` and lets a consumer hold `&mut self` to fold events while the stream is alive.
+    fn handle_stream(
+        &self,
+        command: Self::Command,
+        services: &Self::Services,
+    ) -> impl Future<Output = HandleStreamResult<Self::Event, Self::Error>> + Send
+    where
+        Self::Event: 'static,
+        Self::Error: 'static,
+    {
+        async move {
+            let events = self.handle(command, services).await?;
+            Ok(futures::stream::iter(events.into_iter().map(Ok)).boxed())
+        }
+    }
 
     fn handle_and_apply<'a>(
         &'a mut self,
@@ -75,9 +120,18 @@ pub trait Aggregate: Sync + Send + EventStream {
 ///
 /// # Methods
 /// - `handle`: Validates and processes a command, returning the resulting events or an error.
+/// - `handle_stream`: Stream-first variant of `handle` that yields events lazily instead of
+///   buffering them in a `Vec`.  Use this for commands that may emit very large batches.
 /// - `handle_and_apply`: Processes a command and, if successful, applies the resulting events to the aggregate instance. This is a convenience method for typical aggregate workflows where you want to both validate and mutate state in one step.
 /// - `with_id`: Creates a new aggregate instance with the given id (recommended constructor).
 /// - `id`: Returns the aggregate's identifier (URN).
+///
+/// # `handle` vs `handle_stream`
+/// Implement **at least one** of `handle` / `handle_stream`.  They have one-directional
+/// defaults: `handle` defaults to producing no events, and `handle_stream` defaults to
+/// wrapping `handle`'s `Vec` in a stream.  Implementing only `handle` gives you a streaming
+/// path for free; implementing only `handle_stream` lets a bulk producer avoid ever building
+/// a `Vec`.  Implementing neither compiles but silently emits no events.
 #[cfg(target_arch = "wasm32")]
 pub trait Aggregate: Sync + EventStream {
     type Command;
@@ -89,7 +143,31 @@ pub trait Aggregate: Sync + EventStream {
         &self,
         command: Self::Command,
         services: &Self::Services,
-    ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>>;
+    ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> {
+        let _ = (command, services);
+        async { Ok(Vec::new()) }
+    }
+
+    /// Stream-first variant of [`handle`](Aggregate::handle).
+    ///
+    /// Returns an **owned** stream of `Result<Self::Event, Self::Error>` that does not borrow
+    /// the aggregate, so a caller can fold each event into the same aggregate as it streams.
+    /// The default wraps [`handle`](Aggregate::handle), so existing aggregates get a streaming
+    /// path for free.
+    fn handle_stream(
+        &self,
+        command: Self::Command,
+        services: &Self::Services,
+    ) -> impl Future<Output = HandleStreamResult<Self::Event, Self::Error>>
+    where
+        Self::Event: 'static,
+        Self::Error: 'static,
+    {
+        async move {
+            let events = self.handle(command, services).await?;
+            Ok(futures::stream::iter(events.into_iter().map(Ok)).boxed_local())
+        }
+    }
 
     fn handle_and_apply<'a>(
         &'a mut self,
@@ -504,5 +582,167 @@ mod tests {
         // Test with wrong namespace should fail
         let result = BankAccountAggregate::with_string_id("urn:wrong-namespace:123");
         assert!(result.is_err());
+    }
+
+    // ── handle_stream ────────────────────────────────────────────────────────
+
+    // An aggregate that implements only `handle` gets a streaming path for free:
+    // the default `handle_stream` wraps `handle`'s `Vec` in a stream.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn test_handle_stream_defaults_to_handle() {
+        use futures::TryStreamExt;
+        use urn::UrnBuilder;
+
+        let bank_id = BankAccountUrn(UrnBuilder::new("bank-account", "stream-1").build().unwrap());
+        let aggregate = BankAccountAggregate::with_id(bank_id);
+        let services = BankAccountServices;
+
+        let command = BankAccountCommand::OpenAccount {
+            account_number: "123456".to_string(),
+        };
+
+        // Streaming yields exactly what `handle` would have returned.
+        let stream = aggregate
+            .handle_stream(command.clone(), &services)
+            .await
+            .unwrap();
+        let streamed: Vec<BankAccountEvent> = stream.try_collect().await.unwrap();
+        let collected = aggregate.handle(command, &services).await.unwrap();
+
+        assert_eq!(streamed, collected);
+        assert_eq!(
+            streamed,
+            vec![BankAccountEvent::AccountOpened {
+                account_number: "123456".to_string()
+            }]
+        );
+    }
+
+    // A bulk aggregate that implements ONLY `handle_stream`: it never builds a
+    // `Vec`, and its `handle` default produces no events.
+    #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+    enum ImportCommand {
+        ImportRows { count: u64 },
+    }
+
+    #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+    enum ImportEvent {
+        RowImported { n: u64 },
+    }
+
+    impl crate::Event for ImportEvent {
+        fn event_type(&self) -> String {
+            "RowImported".to_string()
+        }
+    }
+
+    #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+    struct ImportUrn(Urn);
+
+    impl From<ImportUrn> for Urn {
+        fn from(urn: ImportUrn) -> Self {
+            urn.0
+        }
+    }
+
+    impl TryFrom<Urn> for ImportUrn {
+        type Error = String;
+
+        fn try_from(urn: Urn) -> Result<Self, Self::Error> {
+            Ok(ImportUrn(urn))
+        }
+    }
+
+    struct ImportAggregate {
+        id: ImportUrn,
+        total_rows: u64,
+    }
+
+    impl WithId for ImportAggregate {
+        type StreamId = ImportUrn;
+
+        fn with_id(id: Self::StreamId) -> Self {
+            ImportAggregate { id, total_rows: 0 }
+        }
+
+        fn get_id(&self) -> &Self::StreamId {
+            &self.id
+        }
+    }
+
+    impl EventStream for ImportAggregate {
+        type Event = ImportEvent;
+
+        fn stream_type() -> String {
+            "Import".to_string()
+        }
+
+        fn apply(&mut self, event: Self::Event) {
+            match event {
+                ImportEvent::RowImported { .. } => self.total_rows += 1,
+            }
+        }
+    }
+
+    impl Aggregate for ImportAggregate {
+        type Command = ImportCommand;
+        type Error = crate::Error;
+        type Services = ();
+
+        // Only `handle_stream` is implemented — events are produced lazily and a
+        // `Vec` is never materialised.
+        async fn handle_stream(
+            &self,
+            command: Self::Command,
+            _services: &Self::Services,
+        ) -> HandleStreamResult<Self::Event, Self::Error> {
+            let ImportCommand::ImportRows { count } = command;
+            Ok(
+                futures::stream::iter((0..count).map(|n| Ok(ImportEvent::RowImported { n })))
+                    .boxed(),
+            )
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn test_bulk_aggregate_streams_without_vec() {
+        use futures::TryStreamExt;
+        use urn::UrnBuilder;
+
+        let id = ImportUrn(UrnBuilder::new("import", "file-1").build().unwrap());
+        let mut aggregate = ImportAggregate::with_id(id);
+
+        // The stream is owned ('static) and does not borrow the aggregate, so we can
+        // fold each event into `&mut aggregate` while draining the stream.
+        let mut stream = aggregate
+            .handle_stream(ImportCommand::ImportRows { count: 5 }, &())
+            .await
+            .unwrap();
+
+        while let Some(event) = stream.try_next().await.unwrap() {
+            aggregate.apply(event);
+        }
+
+        assert_eq!(aggregate.total_rows, 5);
+    }
+
+    // The `handle` default produces no events for an aggregate that overrides only
+    // `handle_stream`.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn test_handle_default_is_empty() {
+        use urn::UrnBuilder;
+
+        let id = ImportUrn(UrnBuilder::new("import", "file-2").build().unwrap());
+        let aggregate = ImportAggregate::with_id(id);
+
+        let events = aggregate
+            .handle(ImportCommand::ImportRows { count: 3 }, &())
+            .await
+            .unwrap();
+
+        assert!(events.is_empty());
     }
 }

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -750,10 +750,7 @@ async fn bootstrap_position(
                     .fetch_one(pool)
                     .await
                     .map_err(crate::db_error)?;
-            Ok(match head {
-                Some(position) => position,
-                None => 0,
-            })
+            Ok(head.unwrap_or_default())
         }
     }
 }


### PR DESCRIPTION
## Summary

Introduces the stream-first event-emission entry point on `Aggregate` (slice 1 of #100).

- Adds `Aggregate::handle_stream`, returning an **owned**, boxed stream of `Result<Event, Error>` that does **not** borrow the aggregate. This lets a caller fold each event into the same aggregate as it streams (apply-as-you-stream over `&mut self`), which is required for the large-batch use case without materialising a `Vec`.
- `handle` now has a default returning an empty `Vec`, so an aggregate may implement **either** `handle` or `handle_stream`.
- `handle_stream` defaults to wrapping `handle`, so existing aggregates get a streaming path for free.
- Defaults are **one-directional** (`handle_stream` → `handle`); there is no mutual recursion.
- Both cfg arms updated: native (`BoxStream` + `Send`) and `wasm32` (`LocalBoxStream`), via a `HandleStreamResult<E, Err>` type alias (also keeps `clippy::type_complexity` happy).
- Adds ADR-0005 recording the stream-first design.
- Drive-by: fixes a pre-existing `clippy::manual_unwrap_or_default` lint in `policy_runner` that blocked the workspace clippy gate.

## Tests

- `test_handle_stream_defaults_to_handle` — an aggregate implementing only `handle` streams its events.
- `test_bulk_aggregate_streams_without_vec` — an aggregate implementing only `handle_stream` produces events lazily and folds them into `&mut self` while the stream is alive (no `Vec`).
- `test_handle_default_is_empty` — the new `handle` default returns no events.

## Validation

- `cargo test -p es-replay --lib` — 48 passed.
- `cargo build -p es-replay --target wasm32-unknown-unknown` — clean.
- `cargo build --workspace` — clean.

Docker-dependent Postgres integration tests are not run in this environment; no persistence behaviour changed in this slice.

Closes #101
