### PR TITLE
fix(persistence): check expected_version once on streamed append

### DIFF
--- a/persistence/src/infrastructure/in_memory_store.rs
+++ b/persistence/src/infrastructure/in_memory_store.rs
@@ -800,7 +800,12 @@ mod tests {
             )
             .await;
 
-        assert!(result.is_err());
+        let err = result.expect_err("stale expected_version must conflict");
+        assert_eq!(
+            err.kind(),
+            replay::ErrorKind::Conflict,
+            "stale append must surface an optimistic-concurrency conflict"
+        );
 
         let stream_events = store
             .stream_events::<BankAccountEvent>(StreamFilter::with_stream_id::<BankAccountStream>(

--- a/persistence/src/infrastructure/in_memory_store.rs
+++ b/persistence/src/infrastructure/in_memory_store.rs
@@ -733,6 +733,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn store_events_stream_multi_event_with_expected_version_succeeds() {
+        // Parity with the Postgres regression guard: a multi-event append with a correct
+        // expected version is validated once at the head and then appends every event.
+        let store = InMemoryEventStore::new();
+        let stream_id = make_stream_id("stream-multi-expected");
+        let events = vec![
+            BankAccountEvent::Deposited { amount: 100.0 },
+            BankAccountEvent::Withdrawn { amount: 40.0 },
+            BankAccountEvent::Deposited { amount: 10.0 },
+        ];
+
+        let mut observed_versions = Vec::new();
+        store
+            .store_events_stream::<BankAccountStream, _, _>(
+                &stream_id,
+                "BankAccount".to_string(),
+                replay::Metadata::default(),
+                futures::stream::iter(events.into_iter().map(Ok::<_, replay::Error>)),
+                Some(0),
+                |event: &PersistedEvent<BankAccountEvent>| observed_versions.push(event.version),
+            )
+            .await
+            .expect("multi-event append with correct expected version must succeed");
+
+        assert_eq!(observed_versions, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn store_events_stream_stale_expected_version_conflicts() {
+        let store = InMemoryEventStore::new();
+        let stream_id = make_stream_id("stream-stale-expected");
+
+        // Advance the stream to version 1.
+        store
+            .store_events_stream::<BankAccountStream, _, _>(
+                &stream_id,
+                "BankAccount".to_string(),
+                replay::Metadata::default(),
+                futures::stream::iter(
+                    vec![Ok::<_, replay::Error>(BankAccountEvent::Deposited {
+                        amount: 100.0,
+                    })]
+                    .into_iter(),
+                ),
+                Some(0),
+                crate::NoSink,
+            )
+            .await
+            .expect("first append must succeed");
+
+        // A second append still expecting version 0 must conflict and persist nothing new.
+        let result = store
+            .store_events_stream::<BankAccountStream, _, _>(
+                &stream_id,
+                "BankAccount".to_string(),
+                replay::Metadata::default(),
+                futures::stream::iter(
+                    vec![Ok::<_, replay::Error>(BankAccountEvent::Deposited {
+                        amount: 5.0,
+                    })]
+                    .into_iter(),
+                ),
+                Some(0),
+                crate::NoSink,
+            )
+            .await;
+
+        assert!(result.is_err());
+
+        let stream_events = store
+            .stream_events::<BankAccountEvent>(StreamFilter::with_stream_id::<BankAccountStream>(
+                &stream_id,
+            ))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(stream_events.len(), 1, "stale append must not persist");
+    }
+
+    #[tokio::test]
     async fn store_events_stream_rolls_back_on_producer_error() {
         let store = InMemoryEventStore::new();
         let stream_id = make_stream_id("stream-producer-error");

--- a/persistence/src/infrastructure/postgres.rs
+++ b/persistence/src/infrastructure/postgres.rs
@@ -456,10 +456,19 @@ impl EventStore for PostgresEventStore {
         // never has to live fully in memory.
         let mut domain_events = std::pin::pin!(domain_events.into_stream());
 
+        let mut is_first = true;
         while let Some(event) = domain_events.try_next().await? {
             let event_type = event.event_type().clone();
             let event_data = serde_json::to_value(&event).map_err(crate::ser_error)?;
             let id = Uuid::new_v4();
+
+            // Optimistic concurrency is checked once, on the first append only. The caller's
+            // expected version is matched against the stream head inside `append_event`,
+            // whose `SELECT ... FOR UPDATE` locks the stream row for the rest of the
+            // transaction. Subsequent appends pass a NULL expected version: the version has
+            // been incremented under the lock we already hold, so re-checking it against the
+            // original expectation would spuriously conflict.
+            let expected = if is_first { expected_version } else { None };
 
             let row = sqlx::query(
                 "SELECT id, version, created FROM append_event($1, $2, $3, $4, $5, $6, $7)",
@@ -470,14 +479,14 @@ impl EventStore for PostgresEventStore {
             .bind(&event_type)
             .bind(stream_id.to_string())
             .bind(&stream_type)
-            .bind(expected_version)
+            .bind(expected)
             .fetch_optional(&mut *transaction)
             .await
             .map_err(crate::db_error)?;
 
-            // No row means optimistic-concurrency mismatch in append_event. Surface it as a
-            // concurrency_error (parity with the in-memory store) and let the transaction
-            // roll back so no partial append commits.
+            // No row means an optimistic-concurrency mismatch in `append_event` (only
+            // possible on the first append). Surface it as a concurrency_error and let the
+            // transaction roll back so no partial append commits.
             let Some(row) = row else {
                 let actual_version: i64 =
                     sqlx::query_scalar("SELECT version FROM streams WHERE id = $1")
@@ -493,6 +502,8 @@ impl EventStore for PostgresEventStore {
                     actual_version,
                 ));
             };
+
+            is_first = false;
 
             let persisted_id: Uuid = row.get("id");
             let version: i64 = row.get("version");

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -476,6 +476,80 @@ async fn bank_account_store_events_concurrency_conflict_postgres_test() {
     assert_eq!(event_count, 1);
 }
 
+/// Regression guard for the latent per-event concurrency bug: a multi-event streamed append
+/// against a fresh stream with a correct `expected_version` must succeed for *every* event,
+/// not just the first. Previously the expected version was re-checked per event against a
+/// stream version that incremented on each append, so the second event always conflicted.
+#[tokio::test]
+async fn bank_account_multi_event_append_with_expected_version_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+
+    let stream_id = BankAccountUrn::new("multi-event-1").unwrap();
+    let stream_id_str = Into::<Urn>::into(stream_id.clone()).to_string();
+
+    // Three events appended in one call, expecting the stream to start at version 0.
+    let mut observed_versions = Vec::new();
+    store
+        .store_events_stream::<BankAccount, _, _>(
+            &stream_id,
+            "bank-account".to_string(),
+            replay::Metadata::default(),
+            futures::stream::iter(vec![
+                Ok(BankAccountEvent::Deposited {
+                    operation_date: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+                    amount: 100.0,
+                }),
+                Ok(BankAccountEvent::Withdrawn {
+                    operation_date: chrono::NaiveDate::from_ymd_opt(2025, 1, 2).unwrap(),
+                    amount: 40.0,
+                }),
+                Ok(BankAccountEvent::Deposited {
+                    operation_date: chrono::NaiveDate::from_ymd_opt(2025, 1, 3).unwrap(),
+                    amount: 10.0,
+                }),
+            ]),
+            Some(0),
+            |event: &PersistedEvent<BankAccountEvent>| observed_versions.push(event.version),
+        )
+        .await
+        .expect("multi-event append with correct expected version must succeed");
+
+    assert_eq!(
+        observed_versions,
+        vec![1, 2, 3],
+        "every event is appended with a monotonically increasing version"
+    );
+
+    let event_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE stream_id = $1")
+        .bind(&stream_id_str)
+        .fetch_one(&pg_pool)
+        .await
+        .expect("counting events must succeed");
+    assert_eq!(event_count, 3, "all three events are durably persisted");
+
+    let head_version: i64 = sqlx::query_scalar("SELECT version FROM streams WHERE id = $1")
+        .bind(&stream_id_str)
+        .fetch_one(&pg_pool)
+        .await
+        .expect("reading stream head must succeed");
+    assert_eq!(head_version, 3, "stream head advanced once per event");
+}
+
 #[tokio::test]
 async fn bank_account_store_events_stream_sink_postgres_test() {
     let container = postgres::Postgres::default().start().await.unwrap();


### PR DESCRIPTION
## What

A streamed append now validates the caller's `expected_version` **once** — on the
first per-event append — instead of re-checking it on every event.

## Why

`store_events_stream` passed `expected_version` to every `append_event` call. But
the stream version increments on each append, so a multi-event streamed append with
an expected version matched on the first event and **conflicted on the second** —
making multi-event appends with optimistic concurrency impossible.

## How

Postgres already performs the optimistic-concurrency check inside `append_event`,
whose `SELECT ... FOR UPDATE` locks the stream row for the rest of the transaction.
The fix is therefore minimal: supply the caller's expected version on the **first**
append only, and a `NULL` expected version thereafter. Subsequent appends serialise
behind the lock we already hold, and re-checking the now-incremented version against
the original expectation would spuriously conflict.

- **No new SQL or migration** is required.
- **No extra round-trip** per append (important now that inline projections already
  add round-trips).
- The in-memory store checks `expected_version` once at the head of
  `store_events_stream`.

## Tests

- Postgres: multi-event append with a correct expected version succeeds for every
  event (regression guard); existing stale-version conflict still holds.
- In-memory: parity tests for both the multi-event success and the stale-version
  conflict.

23 lib + 39 integration tests pass; `cargo fmt --check` and
`cargo clippy --all-targets -D warnings` are clean.

Closes #103
