### PR TITLE
feat(persistence): Cqrs::execute drives handle_stream with apply-as-you-stream

### DIFF
--- a/persistence/src/cqrs.rs
+++ b/persistence/src/cqrs.rs
@@ -4,7 +4,7 @@ use futures::{StreamExt, TryStreamExt};
 
 use replay::{Aggregate, Event};
 
-use super::{AggregateVersion, EventStore};
+use super::{AggregateVersion, EventStore, PersistedEvent};
 
 #[derive(Clone)]
 pub struct Cqrs<ES: EventStore> {
@@ -82,7 +82,11 @@ impl<ES: EventStore> Cqrs<ES> {
         command: A::Command,
         services: &A::Services,
         expected_version: Option<i64>,
-    ) -> Result<A, A::Error> {
+    ) -> Result<A, A::Error>
+    where
+        A::Event: 'static,
+        A::Error: 'static,
+    {
         // Always load the latest (current) event stream for command handling.
         let mut aggregate = self
             .fetch_aggregate_at::<A>(id, AggregateVersion::Latest, expected_version, None)
@@ -90,14 +94,29 @@ impl<ES: EventStore> Cqrs<ES> {
 
         let stream_type = A::stream_type();
 
-        let events = aggregate.handle(command, services).await?;
+        // Stream-first: the producer yields events lazily and owns its data — it does not
+        // borrow the aggregate — so once it is built the borrow on `&aggregate` is released
+        // and we can fold each persisted event back into the same aggregate as it streams
+        // into the store (apply-as-you-stream). Events are never buffered in a `Vec`.
+        //
+        // A producer error is fatal and rolls back the whole append; it is surfaced to the
+        // store as a `replay::Error` so the streaming contract (`Error = replay::Error`) holds.
+        let event_stream = aggregate
+            .handle_stream(command, services)
+            .await?
+            .map_err(|e| replay::Error::internal("aggregate event producer failed").with_source(e));
 
         self.store
-            .store_events::<A>(id, stream_type, metadata, &events, expected_version)
+            .store_events_stream::<A, _, _>(
+                id,
+                stream_type,
+                metadata,
+                event_stream,
+                expected_version,
+                |event: &PersistedEvent<A::Event>| aggregate.apply(event.data.clone()),
+            )
             .await
             .map_err(A::Error::from)?;
-
-        aggregate.apply_all(events);
 
         Ok(aggregate)
     }

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -3760,3 +3760,160 @@ async fn policy_daemon_reacts_without_notify_via_polling_postgres_test() {
         "policy must react via polling even when NOTIFY is disabled"
     );
 }
+
+// ── Stream-first aggregate via `Cqrs::execute` (issue #104) ──────────────────
+//
+// `Cqrs::execute` now drives `handle_stream` and folds each persisted event back
+// into the in-memory aggregate as it streams into the store (apply-as-you-stream).
+// The existing `bank_account_*` tests cover a `handle`-only aggregate end to end;
+// these cover an aggregate that implements *only* `handle_stream` and never builds
+// a `Vec`.
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+enum ImportEvent {
+    RowImported { n: u64 },
+}
+
+impl replay::Event for ImportEvent {
+    fn event_type(&self) -> String {
+        "RowImported".to_string()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, Urn)]
+struct ImportUrn(Urn);
+
+enum ImportCommand {
+    ImportRows { count: u64 },
+}
+
+/// A bulk-import aggregate that folds only a bounded counter while emitting an
+/// arbitrarily large event stream. It implements *only* `handle_stream`, so its
+/// `handle` default produces no events and a `Vec` is never materialised.
+struct ImportAggregate {
+    id: ImportUrn,
+    total_rows: u64,
+}
+
+impl replay::WithId for ImportAggregate {
+    type StreamId = ImportUrn;
+
+    fn with_id(id: Self::StreamId) -> Self {
+        ImportAggregate { id, total_rows: 0 }
+    }
+
+    fn get_id(&self) -> &Self::StreamId {
+        &self.id
+    }
+}
+
+impl replay::EventStream for ImportAggregate {
+    type Event = ImportEvent;
+
+    fn stream_type() -> String {
+        "Import".to_string()
+    }
+
+    fn apply(&mut self, event: Self::Event) {
+        match event {
+            ImportEvent::RowImported { .. } => self.total_rows += 1,
+        }
+    }
+}
+
+impl replay::Aggregate for ImportAggregate {
+    type Command = ImportCommand;
+    type Error = replay::Error;
+    type Services = ();
+
+    async fn handle_stream(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<futures::stream::BoxStream<'static, Result<Self::Event, Self::Error>>, Self::Error>
+    {
+        use futures::StreamExt;
+        let ImportCommand::ImportRows { count } = command;
+        Ok(futures::stream::iter((0..count).map(|n| Ok(ImportEvent::RowImported { n }))).boxed())
+    }
+}
+
+/// A `handle_stream`-only aggregate round-trips through `execute` against the
+/// in-memory store: every event is folded into the returned aggregate and every
+/// event is persisted, in order. Runs without Docker.
+#[tokio::test]
+async fn import_streaming_aggregate_executes_via_handle_stream_in_memory_test() {
+    let store = replay_persistence::InMemoryEventStore::new();
+    let cqrs = replay_persistence::Cqrs::new(store);
+
+    let stream_id = ImportUrn::new("file-in-memory").unwrap();
+
+    let aggregate = cqrs
+        .execute::<ImportAggregate>(
+            &stream_id,
+            replay::Metadata::default(),
+            ImportCommand::ImportRows { count: 1000 },
+            &(),
+            None,
+        )
+        .await
+        .expect("streaming aggregate must round-trip through execute");
+
+    // Apply-as-you-stream: the folded aggregate counts every event without buffering.
+    assert_eq!(aggregate.total_rows, 1000);
+
+    // Every produced event was persisted: replaying the stream folds back to 1000.
+    let replayed = cqrs
+        .fetch_aggregate::<ImportAggregate>(&stream_id)
+        .await
+        .expect("replaying the persisted stream must succeed");
+    assert_eq!(replayed.total_rows, 1000);
+}
+
+/// End-to-end parity with the in-memory test against a real Postgres backend: a
+/// `handle_stream`-only aggregate is appended under one transaction and the folded
+/// aggregate reflects every streamed event.
+#[tokio::test]
+async fn import_streaming_aggregate_executes_via_handle_stream_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store.clone());
+
+    let stream_id = ImportUrn::new("file-postgres").unwrap();
+
+    let aggregate = cqrs
+        .execute::<ImportAggregate>(
+            &stream_id,
+            replay::Metadata::default(),
+            ImportCommand::ImportRows { count: 1000 },
+            &(),
+            None,
+        )
+        .await
+        .expect("streaming aggregate must round-trip through execute");
+
+    assert_eq!(aggregate.total_rows, 1000);
+
+    // Every produced event was persisted exactly once, in order, under one transaction.
+    let persisted: Vec<PersistedEvent<ImportEvent>> = store
+        .stream_events::<ImportEvent>(StreamFilter::with_stream_id::<ImportAggregate>(&stream_id))
+        .try_collect()
+        .await
+        .expect("streaming persisted events must succeed");
+
+    assert_eq!(persisted.len(), 1000);
+    let versions: Vec<i64> = persisted.iter().map(|e| e.version).collect();
+    assert_eq!(versions, (1..=1000).collect::<Vec<_>>());
+}


### PR DESCRIPTION
## What

`Cqrs::execute` now drives the stream-first producer (`handle_stream`) end to end:
it streams the aggregate's events straight into the store under one transaction and
folds each persisted event back into the in-memory aggregate **as it streams**
(apply-as-you-stream), still returning the folded aggregate. This completes the
stream-first epic (#100).

## Why

`execute` previously called `handle`, buffered the resulting `Vec<Event>`, handed
the whole slice to `store_events`, and only then folded it with `apply_all`. A bulk
command that emits a very large batch had to materialise every event in memory just
to pass it to the store. With the streaming path landed (#101, #102, #103), the last
piece was to wire `execute` to use it.

## How

- `execute` calls only `handle_stream` (no longer `handle`).
- It drives the producer stream into `store_events_stream`, supplying a sink closure
  that folds each `PersistedEvent` into the in-memory aggregate. Events are never
  retained in a `Vec`.
- The producer's owned, `'static` event stream does not borrow the aggregate, so the
  borrow taken to build it is released before the sink folds events into
  `&mut aggregate` — no borrow conflict.
- A fatal producer error is surfaced to the store as a `replay::Error` (via
  `with_source`) so the streaming contract (`Error = replay::Error`) holds and the
  whole append rolls back.
- Existing `handle`-only aggregates flow through unchanged via the `handle_stream`
  default; `execute` still returns the folded aggregate, so current call sites and
  assertions are unaffected.

## Tests

- New `handle_stream`-only bulk-import aggregate (`ImportAggregate`) round-trips
  through `execute`:
  - in-memory (Docker-free): folds all 1000 events and replays back to 1000.
  - Postgres E2E: appends 1000 events under one transaction; the folded aggregate
    counts them all and every event is persisted in order (versions `1..=1000`).
- The existing `bank_account_postgres_test` (a `handle`-only aggregate) still passes
  unchanged through the rewritten `execute`, covering the second aggregate style.
- 23 lib tests pass; `cargo fmt --check` and
  `cargo clippy --all-targets -D warnings` are clean.

Closes #104
