### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["es", "macros", "persistence", "macros-tests"]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["Carlos Verdes <cverdes@gmail.com>"]
 license = "MIT"

--- a/macros-tests/Cargo.toml
+++ b/macros-tests/Cargo.toml
@@ -12,8 +12,8 @@ readme.workspace = true
 name = "replay_macros_tests"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.5.0" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.5.0" }
+replay = { package = "es-replay", path = "../es", version = "0.6.0" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.6.0" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 name = "replay_macros"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.5.0" }
+replay = { package = "es-replay", path = "../es", version = "0.6.0" }
 proc-macro2 = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }

--- a/persistence/Cargo.toml
+++ b/persistence/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["lib"]
 name = "replay_persistence"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.5.0" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.5.0" }
+replay = { package = "es-replay", path = "../es", version = "0.6.0" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.6.0" }
 
 serde = { workspace = true }
 serde_with = { workspace = true }


### PR DESCRIPTION
Release prep for v0.6.0.

Bumps the workspace version 0.5.1 → 0.6.0 and the inter-crate path-dep version strings (es-replay, es-replay-macros) to 0.6.0 across `macros`, `persistence`, and `macros-tests`.

### Included since v0.5.1
- feat(es): stream-first `handle_stream` on `Aggregate` (#109)
- feat(persistence): `store_events_stream` canonical with infallible `EventSink` (#110)
- feat(persistence): `Cqrs::execute` drives `handle_stream` apply-as-you-stream (#112)
- fix(persistence): check `expected_version` once on streamed append (#111)
- docs/chore(skills): address-pr-review skill + review-history hygiene (#113)

No DB migrations. Quality gate (fmt, clippy, tests) green; `cargo publish --dry-run` for `es-replay` packages cleanly.