### PR TITLE
feat(persistence): add dead-letter dimension and Degraded policy status

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,27 @@ applied, and the chain of causation is what bounds how deep one event may
 cascade into further reactions.
 _Avoid_: trigger, cause, origin.
 
+### Dead letter
+
+A recorded failure of a [Policy] reaction that could not be completed — a
+_recorded skip_, never a silent one. When a reaction fails permanently (or
+exhausts its retries) the runner stores a dead letter and advances past the
+triggering event so a single bad event never wedges the Policy. Dead letters are
+queryable so an operator can later inspect and, eventually, explicitly retry
+them.
+_Avoid_: poison message, failed event, error queue.
+
+### Policy status
+
+A point-in-time, read-only snapshot of a [Policy]'s operational progress and
+health — how far behind the event log it is and whether its reactions are
+failing — intended for a human monitoring the system. It is **not** domain
+state (an [Aggregate]'s rebuilt-from-stream state) and **not** a [Projection]
+(it derives no read model from the event log; it reports on a Policy's runtime).
+_Observing_ a Policy's status (read-only) is a separate concern from
+_controlling_ a Policy (acting on its failures, e.g. retrying a [Dead letter]).
+_Avoid_: state, policy state, health check.
+
 ### Query
 
 The existing on-demand, in-memory fold over filtered events. It is the
@@ -86,6 +107,8 @@ background process. A future [Async projection] aimed at client/edge targets
 would need to honour the WASM dual-cfg pattern.
 
 [Aggregate]: #aggregate
+[Policy]: #policy
+[Dead letter]: #dead-letter
 [Query]: #query
 [Live projection]: #live-projection
 [Inline projection]: #inline-projection

--- a/persistence/src/policy_status.rs
+++ b/persistence/src/policy_status.rs
@@ -117,7 +117,9 @@ impl PolicyStatusStore {
     ///
     /// The result is produced by a **single** SQL read that joins
     /// `policy_cursors`, `MAX(global_position)` on `events`, and a per-policy
-    /// aggregate over `policy_dead_letters`.  The event log is never scanned.
+    /// `LATERAL` aggregate over `policy_dead_letters`.  The lateral is filtered
+    /// by `pc.name`, so it uses the `(policy_name, created_at)` index instead of
+    /// aggregating the whole dead-letter table.  The event log is never scanned.
     pub async fn list(&self) -> Result<Vec<PolicyStatus>, replay::Error> {
         let rows = sqlx::query(
             r#"
@@ -133,14 +135,13 @@ impl PolicyStatusStore {
                 SELECT COALESCE(MAX(global_position), 0) AS head
                 FROM events
             ) h
-            LEFT JOIN (
+            LEFT JOIN LATERAL (
                 SELECT
-                    policy_name,
                     COUNT(*)        AS dead_letter_count,
                     MAX(created_at) AS last_dead_letter_at
                 FROM policy_dead_letters
-                GROUP BY policy_name
-            ) dl ON dl.policy_name = pc.name
+                WHERE policy_name = pc.name
+            ) dl ON TRUE
             ORDER BY pc.name
             "#,
         )
@@ -185,11 +186,11 @@ mod tests {
 
     /// Pure derivation test — no database required.
     ///
-    /// Verifies the [`PolicyCondition::from_fields`] precedence:
-    /// `dead_letter_count > 0` → `Degraded`, else `lag > 0` → `Working`,
-    /// else `CaughtUp`.
+    /// Verifies the [`PolicyCondition::from_fields`] precedence as surfaced on a
+    /// fully-built [`PolicyStatus`]: `dead_letter_count > 0` → `Degraded`, else
+    /// `lag > 0` → `Working`, else `CaughtUp`.
     #[test]
-    fn policy_condition_derived_from_lag() {
+    fn policy_status_condition_derived_from_fields() {
         let now = Utc::now();
 
         // lag == 0, no dead letters: caught up

--- a/persistence/src/policy_status.rs
+++ b/persistence/src/policy_status.rs
@@ -1,8 +1,9 @@
 //! Policy status read model.
 //!
 //! [`PolicyStatusStore`] reads operational tables that the runner already
-//! writes (`policy_cursors` + `events`) and returns one [`PolicyStatus`] per
-//! known policy — a lightweight health/lag signal for monitoring.
+//! writes (`policy_cursors`, `events`, and `policy_dead_letters`) and returns
+//! one [`PolicyStatus`] per known policy — a lightweight health/lag signal for
+//! monitoring.
 //!
 //! This is **not** a Projection: it reads operational tables, not the event
 //! log, and does not use the [`crate::Query`] / [`crate::InlineProjection`]
@@ -15,13 +16,26 @@ use sqlx::{Pool, Postgres};
 
 // ── PolicyCondition ───────────────────────────────────────────────────────────
 
-/// Whether a policy is keeping up with the event log.
+/// Headline health label for a [`PolicyStatus`].
+///
+/// Precedence (highest wins):
+///
+/// | Condition  | When                                |
+/// |------------|-------------------------------------|
+/// | `Degraded` | `dead_letter_count > 0`             |
+/// | `Working`  | `dead_letter_count == 0`, `lag > 0` |
+/// | `CaughtUp` | `dead_letter_count == 0`, `lag == 0`|
+///
+/// A policy that is *both* behind and has dead letters resolves to `Degraded`
+/// so that parked failures are never hidden behind a progress label.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PolicyCondition {
-    /// The policy cursor is at the global head (`lag == 0`).
+    /// No dead letters and no lag: fully healthy and up to date.
     CaughtUp,
-    /// The policy cursor is behind the global head (`lag > 0`).
+    /// No dead letters but lagging behind the global head (`lag > 0`).
     Working,
+    /// At least one dead-letter row exists; needs operator attention.
+    Degraded,
 }
 
 impl PolicyCondition {
@@ -30,6 +44,21 @@ impl PolicyCondition {
         match self {
             PolicyCondition::CaughtUp => "CaughtUp",
             PolicyCondition::Working => "Working",
+            PolicyCondition::Degraded => "Degraded",
+        }
+    }
+
+    /// Derive the condition from the raw `lag` and `dead_letter_count` fields.
+    ///
+    /// Dead letters take precedence over lag: a policy that is both behind and
+    /// has parked failures resolves to [`PolicyCondition::Degraded`].
+    pub fn from_fields(lag: i64, dead_letter_count: i64) -> Self {
+        if dead_letter_count > 0 {
+            PolicyCondition::Degraded
+        } else if lag > 0 {
+            PolicyCondition::Working
+        } else {
+            PolicyCondition::CaughtUp
         }
     }
 }
@@ -55,8 +84,13 @@ pub struct PolicyStatus {
     pub lag: i64,
     /// When the cursor was last advanced (staleness signal).
     pub last_checkpoint_at: DateTime<Utc>,
-    /// Derived condition: [`PolicyCondition::CaughtUp`] when `lag == 0`,
-    /// [`PolicyCondition::Working`] when `lag > 0`.
+    /// Number of dead-letter rows recorded for this policy.
+    pub dead_letter_count: i64,
+    /// Timestamp of the most recent dead-letter row, if any.
+    pub last_dead_letter_at: Option<DateTime<Utc>>,
+    /// Derived condition: [`PolicyCondition::Degraded`] when
+    /// `dead_letter_count > 0`, otherwise [`PolicyCondition::Working`] when
+    /// `lag > 0`, otherwise [`PolicyCondition::CaughtUp`].
     pub condition: PolicyCondition,
 }
 
@@ -81,8 +115,9 @@ impl PolicyStatusStore {
     /// `policy_cursors` row.  A registered-but-never-run policy (no row)
     /// does not appear.
     ///
-    /// The result is produced by a **single** SQL read over `policy_cursors`
-    /// and `MAX(global_position)` on `events`.
+    /// The result is produced by a **single** SQL read that joins
+    /// `policy_cursors`, `MAX(global_position)` on `events`, and a per-policy
+    /// aggregate over `policy_dead_letters`.  The event log is never scanned.
     pub async fn list(&self) -> Result<Vec<PolicyStatus>, replay::Error> {
         let rows = sqlx::query(
             r#"
@@ -90,12 +125,22 @@ impl PolicyStatusStore {
                 pc.name,
                 pc.position,
                 h.head,
-                pc.updated_at
+                pc.updated_at,
+                COALESCE(dl.dead_letter_count, 0) AS dead_letter_count,
+                dl.last_dead_letter_at
             FROM policy_cursors pc
             CROSS JOIN (
                 SELECT COALESCE(MAX(global_position), 0) AS head
                 FROM events
             ) h
+            LEFT JOIN (
+                SELECT
+                    policy_name,
+                    COUNT(*)        AS dead_letter_count,
+                    MAX(created_at) AS last_dead_letter_at
+                FROM policy_dead_letters
+                GROUP BY policy_name
+            ) dl ON dl.policy_name = pc.name
             ORDER BY pc.name
             "#,
         )
@@ -111,18 +156,18 @@ impl PolicyStatusStore {
                 let position: i64 = r.get("position");
                 let head: i64 = r.get("head");
                 let updated_at: DateTime<Utc> = r.get("updated_at");
+                let dead_letter_count: i64 = r.get("dead_letter_count");
+                let last_dead_letter_at: Option<DateTime<Utc>> = r.get("last_dead_letter_at");
                 let lag = head - position;
-                let condition = if lag == 0 {
-                    PolicyCondition::CaughtUp
-                } else {
-                    PolicyCondition::Working
-                };
+                let condition = PolicyCondition::from_fields(lag, dead_letter_count);
                 PolicyStatus {
                     name,
                     position,
                     head,
                     lag,
                     last_checkpoint_at: updated_at,
+                    dead_letter_count,
+                    last_dead_letter_at,
                     condition,
                 }
             })
@@ -140,46 +185,79 @@ mod tests {
 
     /// Pure derivation test — no database required.
     ///
-    /// Verifies that `lag == 0` → `CaughtUp` and `lag > 0` → `Working`.
+    /// Verifies the [`PolicyCondition::from_fields`] precedence:
+    /// `dead_letter_count > 0` → `Degraded`, else `lag > 0` → `Working`,
+    /// else `CaughtUp`.
     #[test]
     fn policy_condition_derived_from_lag() {
         let now = Utc::now();
 
-        // lag == 0: caught up
+        // lag == 0, no dead letters: caught up
         let lag0 = PolicyStatus {
             name: "test_policy".to_string(),
             position: 10,
             head: 10,
             lag: 0,
             last_checkpoint_at: now,
-            condition: if 0 == 0 {
-                PolicyCondition::CaughtUp
-            } else {
-                PolicyCondition::Working
-            },
+            dead_letter_count: 0,
+            last_dead_letter_at: None,
+            condition: PolicyCondition::from_fields(0, 0),
         };
         assert_eq!(lag0.condition, PolicyCondition::CaughtUp);
         assert_eq!(lag0.lag, 0);
         assert_eq!(lag0.condition.as_str(), "CaughtUp");
         assert_eq!(lag0.condition.to_string(), "CaughtUp");
 
-        // lag > 0: working
+        // lag > 0, no dead letters: working
         let lag5 = PolicyStatus {
             name: "slow_policy".to_string(),
             position: 5,
             head: 10,
             lag: 5,
             last_checkpoint_at: now,
-            condition: if 5 == 0 {
-                PolicyCondition::CaughtUp
-            } else {
-                PolicyCondition::Working
-            },
+            dead_letter_count: 0,
+            last_dead_letter_at: None,
+            condition: PolicyCondition::from_fields(5, 0),
         };
         assert_eq!(lag5.condition, PolicyCondition::Working);
         assert_eq!(lag5.lag, 5);
         assert_eq!(lag5.condition.as_str(), "Working");
         assert_eq!(lag5.condition.to_string(), "Working");
+
+        // dead letters present: degraded, even when also behind
+        let degraded = PolicyStatus {
+            name: "failing_policy".to_string(),
+            position: 7,
+            head: 10,
+            lag: 3,
+            last_checkpoint_at: now,
+            dead_letter_count: 2,
+            last_dead_letter_at: Some(now),
+            condition: PolicyCondition::from_fields(3, 2),
+        };
+        assert_eq!(degraded.condition, PolicyCondition::Degraded);
+        assert_eq!(degraded.dead_letter_count, 2);
+        assert_eq!(degraded.condition.as_str(), "Degraded");
+        assert_eq!(degraded.condition.to_string(), "Degraded");
+    }
+
+    /// Exhaustive precedence table for [`PolicyCondition::from_fields`].
+    #[test]
+    fn policy_condition_precedence() {
+        assert_eq!(
+            PolicyCondition::from_fields(0, 0),
+            PolicyCondition::CaughtUp
+        );
+        assert_eq!(PolicyCondition::from_fields(5, 0), PolicyCondition::Working);
+        assert_eq!(
+            PolicyCondition::from_fields(0, 3),
+            PolicyCondition::Degraded
+        );
+        // Dead letters win even when the policy is also behind.
+        assert_eq!(
+            PolicyCondition::from_fields(10, 2),
+            PolicyCondition::Degraded
+        );
     }
 
     /// Directly verify the `PolicyCondition` string representations.
@@ -187,7 +265,9 @@ mod tests {
     fn policy_condition_display_and_as_str() {
         assert_eq!(PolicyCondition::CaughtUp.as_str(), "CaughtUp");
         assert_eq!(PolicyCondition::Working.as_str(), "Working");
+        assert_eq!(PolicyCondition::Degraded.as_str(), "Degraded");
         assert_eq!(format!("{}", PolicyCondition::CaughtUp), "CaughtUp");
         assert_eq!(format!("{}", PolicyCondition::Working), "Working");
+        assert_eq!(format!("{}", PolicyCondition::Degraded), "Degraded");
     }
 }

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -3958,11 +3958,10 @@ async fn policy_status_caught_up_postgres_test() {
     .unwrap();
 
     // Read the actual head position so we can place the cursor exactly there.
-    let head: i64 =
-        sqlx::query_scalar("SELECT COALESCE(MAX(global_position), 0) FROM events")
-            .fetch_one(&pg_pool)
-            .await
-            .expect("head query must succeed");
+    let head: i64 = sqlx::query_scalar("SELECT COALESCE(MAX(global_position), 0) FROM events")
+        .fetch_one(&pg_pool)
+        .await
+        .expect("head query must succeed");
 
     // Insert a cursor row at the head — simulates a fully-drained policy.
     sqlx::query(
@@ -3980,10 +3979,7 @@ async fn policy_status_caught_up_postgres_test() {
     assert_eq!(statuses.len(), 1, "one policy must appear");
     let s = &statuses[0];
     assert_eq!(s.name, "caught_up_policy");
-    assert_eq!(
-        s.lag, 0,
-        "cursor is at head, so lag must be 0"
-    );
+    assert_eq!(s.lag, 0, "cursor is at head, so lag must be 0");
     assert_eq!(
         s.condition,
         replay_persistence::PolicyCondition::CaughtUp,
@@ -4110,7 +4106,10 @@ async fn policy_status_multiple_policies_postgres_test() {
 
     let alpha = statuses.iter().find(|s| s.name == "alpha_policy").unwrap();
     assert_eq!(alpha.lag, 0);
-    assert_eq!(alpha.condition, replay_persistence::PolicyCondition::CaughtUp);
+    assert_eq!(
+        alpha.condition,
+        replay_persistence::PolicyCondition::CaughtUp
+    );
 
     let beta = statuses.iter().find(|s| s.name == "beta_policy").unwrap();
     assert_eq!(beta.lag, 1);
@@ -4140,5 +4139,85 @@ async fn policy_status_unregistered_policy_absent_postgres_test() {
     assert!(
         statuses.is_empty(),
         "no cursor rows means no statuses must be returned"
+    );
+}
+
+/// A policy with dead letters is `Degraded`, and dead letters take precedence
+/// over lag.
+///
+/// Setup: append two events (head = 2), insert a cursor behind the head
+/// (position 1, so `lag > 0`), and record one dead-letter row. The status must
+/// surface `dead_letter_count == 1`, a `last_dead_letter_at` timestamp, and
+/// condition `Degraded` — never `Working`, even though the policy is also behind.
+#[tokio::test]
+async fn policy_status_degraded_with_dead_letters_postgres_test() {
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("status-degraded-1").unwrap();
+
+    // Append two events so the global head is 2.
+    for amount in [10.0_f64, 20.0_f64] {
+        cqrs.execute::<BankAccount>(
+            &account,
+            replay::Metadata::default(),
+            BankAccountCommand::Deposit {
+                effective_on: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+                amount,
+            },
+            &(),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    // Cursor behind the head (lag > 0) so we can prove Degraded beats Working.
+    sqlx::query(
+        "INSERT INTO policy_cursors (name, position, updated_at) VALUES ('degraded_policy', 1, now())",
+    )
+    .execute(&pg_pool)
+    .await
+    .expect("cursor insert must succeed");
+
+    // Record one dead-letter row for the policy.
+    sqlx::query(
+        "INSERT INTO policy_dead_letters \
+             (policy_name, global_position, event_id, error_kind, error_message) \
+         VALUES ('degraded_policy', 2, $1, 'Permanent', 'boom')",
+    )
+    .bind(uuid::Uuid::new_v4())
+    .execute(&pg_pool)
+    .await
+    .expect("dead-letter insert must succeed");
+
+    let status_store = replay_persistence::PolicyStatusStore::new(pg_pool.clone());
+    let statuses = status_store.list().await.expect("list must succeed");
+
+    assert_eq!(statuses.len(), 1, "one policy must appear");
+    let s = &statuses[0];
+    assert_eq!(s.name, "degraded_policy");
+    assert!(s.lag > 0, "policy is behind the head, so lag must be > 0");
+    assert_eq!(s.dead_letter_count, 1, "one dead-letter row was recorded");
+    assert!(
+        s.last_dead_letter_at.is_some(),
+        "a dead-letter timestamp must be present"
+    );
+    assert_eq!(
+        s.condition,
+        replay_persistence::PolicyCondition::Degraded,
+        "dead letters must yield Degraded even when the policy is also behind"
     );
 }


### PR DESCRIPTION
Extends the merged policy status read model (slice 1) with the dead-letter dimension requested in #117.

## What

- `PolicyStatus` gains `dead_letter_count: i64` and `last_dead_letter_at: Option<DateTime<Utc>>`.
- `PolicyCondition` gains `Degraded`. Precedence (highest wins): `Degraded` (`dead_letter_count > 0`) > `Working` (`lag > 0`) > `CaughtUp`. A policy that is both behind and dead-lettered resolves to `Degraded` so parked failures are never hidden behind a progress label.
- `PolicyCondition::from_fields(lag, dead_letter_count)` centralises the derivation.
- `PolicyStatusStore::list()` LEFT JOINs a per-policy aggregate over `policy_dead_letters` (`COUNT(*)`, `MAX(created_at)`) in the **same single query**; the event log is never scanned.

## Why this shape

This deliberately **extends** the existing `policy_status` module / `PolicyStatusStore::list()` rather than introducing a parallel `PolicyRunner` API with duplicate `PolicyStatus`/`PolicyCondition` types. Observing stays separated from controlling; field naming (`position`/`head`) stays consistent with slice 1.

## Tests

- Unit: exhaustive `PolicyCondition::from_fields` precedence table.
- Integration: new `policy_status_degraded_with_dead_letters_postgres_test` proves `Degraded` wins even when the policy is also behind; existing caught-up/working/multiple/unregistered tests still pass.

## Docs

- `CONTEXT.md` glossary: **Dead letter**, **Policy status**.

Closes #117