### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["es", "macros", "persistence", "macros-tests"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["Carlos Verdes <cverdes@gmail.com>"]
 license = "MIT"

--- a/macros-tests/Cargo.toml
+++ b/macros-tests/Cargo.toml
@@ -12,8 +12,8 @@ readme.workspace = true
 name = "replay_macros_tests"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.6.0" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.6.0" }
+replay = { package = "es-replay", path = "../es", version = "0.7.0" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.7.0" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 name = "replay_macros"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.6.0" }
+replay = { package = "es-replay", path = "../es", version = "0.7.0" }
 proc-macro2 = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }

--- a/persistence/Cargo.toml
+++ b/persistence/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["lib"]
 name = "replay_persistence"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.6.0" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.6.0" }
+replay = { package = "es-replay", path = "../es", version = "0.7.0" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.7.0" }
 
 serde = { workspace = true }
 serde_with = { workspace = true }


### PR DESCRIPTION
Release 0.7.0.

Bumps the workspace and inter-crate path-dependency versions `0.6.0` → `0.7.0` across `Cargo.toml`, `macros/Cargo.toml`, `persistence/Cargo.toml`, and `macros-tests/Cargo.toml`.

## Included since 0.6.0

- Policy status read model with progress conditions (#119)
- Dead-letter dimension and `Degraded` policy condition (#120)
- Docs: ADR-0006 + README monitoring section (#121)

## Migration

No database migration required: the policy-status feature is pure read-model code over tables already shipped in 0.6.0 (`policy_cursors`, `policy_dead_letters`).

Note: `PolicyCondition` gains a `Degraded` variant — downstream exhaustive `match` on it will need the new arm, hence the minor bump.