### PR TITLE
fix(persistence): collapse policy runner connection footprint to O(1)

### DIFF
--- a/docs/adr/0008-policy-runner-shared-connection-leadership.md
+++ b/docs/adr/0008-policy-runner-shared-connection-leadership.md
@@ -30,6 +30,15 @@ rather than linear.
   The manager publishes per-policy leadership on a `tokio::sync::watch<bool>` that
   each worker observes. On shutdown it explicitly `pg_advisory_unlock`s the held
   keys so a standby takes over without waiting for a TCP session timeout.
+- **The lock manager detects loss of its pinned session.** Because a single
+  connection holds every lock, losing it silently would otherwise leave workers
+  draining as stale leaders (Postgres releases the locks server-side, but the
+  in-memory `held` flags would not know). Each tick the manager runs a cheap
+  liveness probe on the connection while it leads at least one policy; any probe or
+  lock-query error revokes all locally-believed leadership (flipping every worker's
+  `watch` to false so they stop draining) and reconnects to recompete for the keys
+  from scratch. This bounds any split-brain window to a single poll `interval`
+  rather than "until the process restarts".
 - **One shared `PgListener` task per runner**, holding **one** connection, receives
   every append `NOTIFY` and fans each wakeup out to all workers in-process via a
   `tokio::sync::broadcast<()>` channel. This is consistent with ADR-0003's rule that
@@ -52,13 +61,13 @@ rather than linear.
   an 8-connection pool (the old design needed 24) all process the trigger event.
 - **Failover granularity is coarser**, and this is the deliberate trade-off. Because
   all of an instance's advisory locks live on one session, when that session drops
-  (process death, connection loss) **all** of that instance's policies fail over to a
-  standby together, rather than each failing over independently. This is acceptable:
-  each policy is still recovered **independently and exactly once** from its stored
-  cursor, and instance-granularity failover matches how processes actually fail (the
-  whole process, not one policy's connection). The previous per-policy failover
-  granularity was an accident of the per-policy-connection implementation, not a
-  designed guarantee.
+  (process death, or connection loss detected by the liveness probe) **all** of that
+  instance's policies fail over to a standby together, rather than each failing over
+  independently. This is acceptable: each policy is still recovered **independently
+  and exactly once** from its stored cursor, and instance-granularity failover
+  matches how processes actually fail (the whole process, not one policy's
+  connection). The previous per-policy failover granularity was an accident of the
+  per-policy-connection implementation, not a designed guarantee.
 - The `Policy` trait, `Dispatch` descriptor, cursor/checkpoint semantics, dead-letter
   handling, causation-depth loop limit, and `start_at` behaviour are all untouched —
   this is purely a change to how the *runner* maps policies onto connections. No

--- a/docs/adr/0008-policy-runner-shared-connection-leadership.md
+++ b/docs/adr/0008-policy-runner-shared-connection-leadership.md
@@ -1,0 +1,69 @@
+# Policy runner shares one lock connection and one listener across all policies
+
+**Status:** accepted
+
+ADR-0003 chose a runtime of **one long-lived `tokio` task per policy** and
+**single-active-runner-per-policy via `pg_advisory_lock`**, with optional
+`LISTEN/NOTIFY` as a latency hint. That shape was correct, but its first
+implementation pinned **two** dedicated Postgres connections *per policy* for the
+whole leadership tenure: one connection holding the policy's session-scoped
+advisory lock, and a second connection running a `PgListener` for `NOTIFY`. With
+`P` policies that is `O(2P)` permanently-held connections. Once `2P` exceeds the
+shared SQLx pool's `max_connections`, later policies can never acquire their
+connections and silently stop processing — observed in a consuming application as
+a "database connection pool timed out" error (issue #125).
+
+This ADR keeps every correctness property of ADR-0003 (single ordered consumer per
+policy, automatic leader failover, polling-as-baseline with NOTIFY-as-hint) but
+makes the steady-state connection footprint **constant in the number of policies**
+rather than linear.
+
+## Decisions
+
+- **One shared lock-manager task per runner**, holding **one** connection, acquires
+  *every* policy's `pg_advisory_lock` on that single session. Postgres session-level
+  advisory locks are per-session and a single session may hold many distinct lock
+  keys simultaneously, so one connection can elect leadership for all `P` policies.
+  Each key is tried independently with non-blocking `pg_try_advisory_lock`, so
+  **different policies still lead on different instances** and **exactly one**
+  instance leads each policy — the single-ordered-consumer guarantee is unchanged.
+  The manager publishes per-policy leadership on a `tokio::sync::watch<bool>` that
+  each worker observes. On shutdown it explicitly `pg_advisory_unlock`s the held
+  keys so a standby takes over without waiting for a TCP session timeout.
+- **One shared `PgListener` task per runner**, holding **one** connection, receives
+  every append `NOTIFY` and fans each wakeup out to all workers in-process via a
+  `tokio::sync::broadcast<()>` channel. This is consistent with ADR-0003's rule that
+  NOTIFY is only a best-effort latency hint, never the source of truth: a lagged,
+  dropped, or missed broadcast is harmless because each worker still wakes on the
+  poll `interval`. The listener task reconnects on error; while it is down, workers
+  degrade to pure polling.
+- **Per-policy worker tasks hold no pinned connection.** A worker waits for its
+  leadership `watch` to go true, loads its cursor, then drains — acquiring only
+  *transient* pooled connections for the duration of each drain and releasing them
+  between polls. The drain loop wakes on `tokio::select!` over shutdown, the
+  leadership signal, the poll interval, and the broadcast wakeup.
+
+## Consequences
+
+- **Steady-state pinned connections are `~2` regardless of policy count** (one lock
+  manager + one listener), plus transient connections borrowed per drain. A runner
+  with dozens of policies no longer exhausts a modest pool. This is verified by
+  `policy_bounded_connection_footprint_many_policies_postgres_test`: 12 policies on
+  an 8-connection pool (the old design needed 24) all process the trigger event.
+- **Failover granularity is coarser**, and this is the deliberate trade-off. Because
+  all of an instance's advisory locks live on one session, when that session drops
+  (process death, connection loss) **all** of that instance's policies fail over to a
+  standby together, rather than each failing over independently. This is acceptable:
+  each policy is still recovered **independently and exactly once** from its stored
+  cursor, and instance-granularity failover matches how processes actually fail (the
+  whole process, not one policy's connection). The previous per-policy failover
+  granularity was an accident of the per-policy-connection implementation, not a
+  designed guarantee.
+- The `Policy` trait, `Dispatch` descriptor, cursor/checkpoint semantics, dead-letter
+  handling, causation-depth loop limit, and `start_at` behaviour are all untouched —
+  this is purely a change to how the *runner* maps policies onto connections. No
+  schema change.
+- The behaviour is covered by the existing Docker-gated Postgres integration tests
+  (single-active-runner failover, NOTIFY-wakes-before-interval, without-notifications
+  polling, dead-letter, and status) plus the new bounded-footprint test, which
+  together remain the executable specification of these contracts.

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -19,7 +19,7 @@ use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sqlx::{Pool, Postgres, QueryBuilder, Row};
-use tokio::sync::watch;
+use tokio::sync::{broadcast, watch};
 use tokio::task::JoinHandle;
 
 use replay::{Aggregate, Metadata};
@@ -266,100 +266,260 @@ impl PolicyRunner {
         Ok(total)
     }
 
-    /// Start one long-lived polling task per registered policy.
+    /// Start one long-lived worker task per registered policy, backed by two
+    /// shared per-process connections rather than two connections per policy.
     ///
-    /// Each task competes for a per-policy `pg_advisory_lock` before entering its
-    /// polling loop.  The lock key is derived from the policy name, so:
+    /// The steady-state connection footprint is **constant** in the number of
+    /// policies `P`, not `O(2P)`, which is what previously exhausted a shared
+    /// SQLx pool when many policies were registered:
     ///
-    /// - **Exactly one** service instance is the active leader for each policy at
-    ///   any moment (single-consumer correctness for the ordered global feed).
-    /// - **Different policies** may run on different instances concurrently.
-    /// - **Leader failover is automatic**: the advisory lock is session-scoped, so
-    ///   when the leader's task (or its host process) dies the lock is released and
-    ///   a standby acquires it on the next poll and resumes from the stored cursor.
+    /// - **One shared lock-manager connection** holds every policy's
+    ///   `pg_advisory_lock`. Postgres session advisory locks are per-session and a
+    ///   single session may hold many distinct lock keys, so one pinned connection
+    ///   elects leadership for all `P` policies. Each key is tried independently,
+    ///   so **different policies may still lead on different instances**, and
+    ///   **exactly one** instance leads each policy (single-consumer correctness
+    ///   for the ordered global feed). The manager publishes per-policy leadership
+    ///   on a [`watch`] channel that each worker observes.
+    /// - **One shared `PgListener` connection** receives `NOTIFY` and fans each
+    ///   wakeup out to every worker in-process via a [`broadcast`] channel, instead
+    ///   of one listener connection per policy. A missed or lagged broadcast is
+    ///   harmless: the worker still wakes on the poll `interval` (polling is the
+    ///   correctness baseline; `NOTIFY` is only a latency hint).
     ///
-    /// Use [`PolicyRunnerDaemon::shutdown`] to stop all tasks cleanly.  Shutdown
-    /// explicitly calls `pg_advisory_unlock` so the standby can take over without
-    /// waiting for a TCP-level session timeout.
+    /// **Leader failover is automatic**: the advisory locks are session-scoped, so
+    /// when a leader process dies its lock-manager connection drops and releases
+    /// all of its locks at once; a standby's lock manager acquires them on its next
+    /// tick and each worker resumes from its stored cursor. The trade-off relative
+    /// to the previous per-policy design is coarser failover granularity — a single
+    /// instance's policies fail over together — which is acceptable because each
+    /// policy is still recovered independently and exactly once.
+    ///
+    /// Use [`PolicyRunnerDaemon::shutdown`] to stop all tasks cleanly. Shutdown
+    /// releases the held advisory locks so a standby can take over without waiting
+    /// for a TCP-level session timeout.
     pub fn start_polling(&self, interval: Duration) -> PolicyRunnerDaemon {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        let mut tasks = Vec::with_capacity(self.policies.len());
+        let mut tasks = Vec::with_capacity(self.policies.len() + 2);
 
+        // ── Shared NOTIFY listener: one connection, broadcast fan-out ─────────
+        // A single PgListener receives every append NOTIFY and rebroadcasts it to
+        // all worker tasks. Workers that lag simply fall back to interval polling.
+        let wake_tx = if self.notifications {
+            let (wake_tx, _) = broadcast::channel::<()>(16);
+            let pool = self.pool.clone();
+            let mut listener_shutdown_rx = shutdown_rx.clone();
+            let tx = wake_tx.clone();
+            tasks.push(tokio::spawn(async move {
+                'reconnect: loop {
+                    if *listener_shutdown_rx.borrow() {
+                        return;
+                    }
+
+                    let mut listener = match sqlx::postgres::PgListener::connect_with(&pool).await {
+                        Ok(mut l) => match l.listen(REPLAY_NOTIFY_CHANNEL).await {
+                            Ok(()) => {
+                                tracing::debug!(
+                                    channel = REPLAY_NOTIFY_CHANNEL,
+                                    "shared LISTEN active; fanning NOTIFY to workers"
+                                );
+                                l
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    error = %error,
+                                    "shared LISTEN setup failed; workers fall back to polling"
+                                );
+                                tokio::select! {
+                                    _ = listener_shutdown_rx.changed() => return,
+                                    _ = tokio::time::sleep(interval) => {}
+                                }
+                                continue 'reconnect;
+                            }
+                        },
+                        Err(error) => {
+                            tracing::warn!(
+                                error = %error,
+                                "shared PgListener connect failed; workers fall back to polling"
+                            );
+                            tokio::select! {
+                                _ = listener_shutdown_rx.changed() => return,
+                                _ = tokio::time::sleep(interval) => {}
+                            }
+                            continue 'reconnect;
+                        }
+                    };
+
+                    loop {
+                        tokio::select! {
+                            changed = listener_shutdown_rx.changed() => {
+                                if changed.is_err() || *listener_shutdown_rx.borrow() {
+                                    return;
+                                }
+                            }
+                            res = listener.recv() => match res {
+                                // Best-effort fan-out; a send error just means no
+                                // live receivers right now, which is fine.
+                                Ok(_) => {
+                                    let _ = tx.send(());
+                                }
+                                Err(error) => {
+                                    tracing::warn!(
+                                        error = %error,
+                                        "shared PgListener recv error; reconnecting"
+                                    );
+                                    continue 'reconnect;
+                                }
+                            }
+                        }
+                    }
+                }
+            }));
+            Some(wake_tx)
+        } else {
+            None
+        };
+
+        // ── Shared lock manager: one connection holds every policy's lock ─────
+        // Per-policy leadership is published on a `watch<bool>` each worker
+        // observes. The manager keeps retrying keys it does not yet hold so a
+        // standby takes over when a current leader releases on shutdown.
+        let mut leadership_rx: HashMap<String, watch::Receiver<bool>> = HashMap::new();
+        let mut leadership: Vec<(String, watch::Sender<bool>)> =
+            Vec::with_capacity(self.policies.len());
+        for policy in &self.policies {
+            let name = policy.name().to_string();
+            let (l_tx, l_rx) = watch::channel(false);
+            leadership_rx.insert(name.clone(), l_rx);
+            leadership.push((name, l_tx));
+        }
+
+        {
+            let pool = self.pool.clone();
+            let mut lock_shutdown_rx = shutdown_rx.clone();
+            tasks.push(tokio::spawn(async move {
+                // One dedicated connection pinned for the whole tenure. All of this
+                // instance's advisory locks live on this single session.
+                let mut lock_conn = loop {
+                    if *lock_shutdown_rx.borrow() {
+                        return;
+                    }
+                    match pool.acquire().await {
+                        Ok(conn) => break conn,
+                        Err(error) => {
+                            tracing::error!(
+                                error = %error,
+                                "lock manager could not acquire its connection; retrying"
+                            );
+                            tokio::select! {
+                                _ = lock_shutdown_rx.changed() => return,
+                                _ = tokio::time::sleep(interval) => {}
+                            }
+                        }
+                    }
+                };
+
+                // Local record of which keys this session currently holds, so we
+                // only try to acquire keys we are not already leading.
+                let mut held = vec![false; leadership.len()];
+
+                loop {
+                    if *lock_shutdown_rx.borrow() {
+                        break;
+                    }
+
+                    for (idx, (name, tx)) in leadership.iter().enumerate() {
+                        if held[idx] {
+                            continue;
+                        }
+                        // pg_try_advisory_lock is non-blocking: returns true only
+                        // when this session exclusively holds the lock for `name`.
+                        match sqlx::query_scalar::<_, bool>(
+                            "SELECT pg_try_advisory_lock(hashtext($1)::bigint)",
+                        )
+                        .bind(name)
+                        .fetch_one(&mut *lock_conn)
+                        .await
+                        {
+                            Ok(true) => {
+                                tracing::info!(policy = %name, "acquired advisory lock; leading");
+                                held[idx] = true;
+                                let _ = tx.send(true);
+                            }
+                            Ok(false) => {
+                                tracing::debug!(
+                                    policy = %name,
+                                    "advisory lock held by another instance; standing by"
+                                );
+                            }
+                            Err(error) => {
+                                tracing::error!(
+                                    policy = %name,
+                                    error = %error,
+                                    "advisory lock query failed"
+                                );
+                            }
+                        }
+                    }
+
+                    tokio::select! {
+                        _ = lock_shutdown_rx.changed() => break,
+                        _ = tokio::time::sleep(interval) => {}
+                    }
+                }
+
+                // Shutdown: explicitly release every held lock so a standby can
+                // take over immediately (without waiting for a TCP session timeout).
+                for (idx, (name, tx)) in leadership.iter().enumerate() {
+                    if held[idx] {
+                        let _ = sqlx::query("SELECT pg_advisory_unlock(hashtext($1)::bigint)")
+                            .bind(name)
+                            .execute(&mut *lock_conn)
+                            .await;
+                        let _ = tx.send(false);
+                    }
+                }
+            }));
+        }
+
+        // ── Per-policy worker tasks ───────────────────────────────────────────
         for policy in &self.policies {
             let policy = Arc::clone(policy);
             let cqrs = self.cqrs.clone();
             let pool = self.pool.clone();
             let executors = self.executors.clone();
-            let notifications = self.notifications;
             let mut policy_shutdown_rx = shutdown_rx.clone();
+            let name = policy.name().to_string();
+            let mut leader_rx = leadership_rx
+                .remove(&name)
+                .expect("every policy has a leadership channel");
+            let mut wake_rx = wake_tx.as_ref().map(broadcast::Sender::subscribe);
 
             tasks.push(tokio::spawn(async move {
-                let name = policy.name().to_string();
+                let max_depth = resolve_max_depth(policy.as_ref());
 
-                // Outer loop: repeatedly attempt to acquire the advisory lock.
-                // A standby instance stays in this loop, sleeping between attempts.
-                'acquire: loop {
+                'lifetime: loop {
                     if *policy_shutdown_rx.borrow() {
                         return;
                     }
 
-                    // Hold a dedicated connection for the session-scoped lock.
-                    // Keeping this connection alive for the full leadership tenure
-                    // ensures the lock is not silently released between polls.
-                    let mut lock_conn = match pool.acquire().await {
-                        Ok(conn) => conn,
-                        Err(error) => {
-                            tracing::error!(
-                                policy = %name,
-                                error = %error,
-                                "policy task could not acquire a connection for advisory lock"
-                            );
-                            tokio::select! {
-                                _ = policy_shutdown_rx.changed() => {}
-                                _ = tokio::time::sleep(interval) => {}
-                            }
-                            continue 'acquire;
-                        }
-                    };
-
-                    // pg_try_advisory_lock is non-blocking: returns true only when
-                    // this session exclusively holds the lock for `name`.
-                    let acquired = match sqlx::query_scalar::<_, bool>(
-                        "SELECT pg_try_advisory_lock(hashtext($1)::bigint)",
-                    )
-                    .bind(&name)
-                    .fetch_one(&mut *lock_conn)
-                    .await
-                    {
-                        Ok(v) => v,
-                        Err(error) => {
-                            tracing::error!(
-                                policy = %name,
-                                error = %error,
-                                "advisory lock query failed"
-                            );
-                            tokio::select! {
-                                _ = policy_shutdown_rx.changed() => {}
-                                _ = tokio::time::sleep(interval) => {}
-                            }
-                            continue 'acquire;
-                        }
-                    };
-
-                    if !acquired {
-                        tracing::debug!(
-                            policy = %name,
-                            "advisory lock held by another instance; standing by"
-                        );
-                        drop(lock_conn);
+                    // Wait until the shared lock manager elects this worker leader.
+                    while !*leader_rx.borrow() {
                         tokio::select! {
-                            _ = policy_shutdown_rx.changed() => {}
-                            _ = tokio::time::sleep(interval) => {}
+                            changed = policy_shutdown_rx.changed() => {
+                                if changed.is_err() || *policy_shutdown_rx.borrow() {
+                                    return;
+                                }
+                            }
+                            changed = leader_rx.changed() => {
+                                if changed.is_err() {
+                                    return;
+                                }
+                            }
                         }
-                        continue 'acquire;
                     }
 
-                    tracing::info!(policy = %name, "acquired advisory lock; running as leader");
+                    tracing::info!(policy = %name, "running as leader");
 
                     // Initialize cursor from the stored checkpoint (or bootstrap).
                     let mut cursor = match load_cursor(&pool, &name, policy.start_at()).await {
@@ -368,56 +528,19 @@ impl PolicyRunner {
                             tracing::error!(
                                 policy = %name,
                                 error = %error,
-                                "leader failed to initialize cursor; releasing lock"
+                                "leader failed to initialize cursor; retrying"
                             );
-                            let _ = sqlx::query("SELECT pg_advisory_unlock(hashtext($1)::bigint)")
-                                .bind(&name)
-                                .execute(&mut *lock_conn)
-                                .await;
-                            return;
-                        }
-                    };
-
-                    // Optionally subscribe to NOTIFY wakeups so the loop reacts to
-                    // new appends immediately rather than waiting out the poll interval.
-                    // Errors here are non-fatal: the task falls back to pure polling.
-                    let mut listener: Option<sqlx::postgres::PgListener> = if notifications {
-                        match sqlx::postgres::PgListener::connect_with(&pool).await {
-                            Ok(mut l) => match l.listen(REPLAY_NOTIFY_CHANNEL).await {
-                                Ok(()) => {
-                                    tracing::debug!(
-                                        policy = %name,
-                                        channel = REPLAY_NOTIFY_CHANNEL,
-                                        "LISTEN active; will wake on NOTIFY"
-                                    );
-                                    Some(l)
-                                }
-                                Err(error) => {
-                                    tracing::warn!(
-                                        policy = %name,
-                                        error = %error,
-                                        "LISTEN setup failed; falling back to polling"
-                                    );
-                                    None
-                                }
-                            },
-                            Err(error) => {
-                                tracing::warn!(
-                                    policy = %name,
-                                    error = %error,
-                                    "PgListener connect failed; falling back to polling"
-                                );
-                                None
+                            tokio::select! {
+                                _ = policy_shutdown_rx.changed() => return,
+                                _ = tokio::time::sleep(interval) => {}
                             }
+                            continue 'lifetime;
                         }
-                    } else {
-                        None
                     };
 
                     // Leadership polling loop.
-                    let max_depth = resolve_max_depth(policy.as_ref());
                     loop {
-                        if *policy_shutdown_rx.borrow() {
+                        if *policy_shutdown_rx.borrow() || !*leader_rx.borrow() {
                             break;
                         }
 
@@ -441,27 +564,28 @@ impl PolicyRunner {
                             }
                         }
 
-                        // Wait for the next wakeup: NOTIFY (if enabled), poll
-                        // timeout, or shutdown signal — whichever fires first.
-                        if let Some(ref mut l) = listener {
+                        // Wait for the next wakeup: NOTIFY broadcast (if enabled),
+                        // poll timeout, leadership change, or shutdown — whichever
+                        // fires first.
+                        if let Some(ref mut wake) = wake_rx {
                             tokio::select! {
                                 changed = policy_shutdown_rx.changed() => {
                                     if changed.is_err() || *policy_shutdown_rx.borrow() {
                                         break;
                                     }
                                 }
-                                _ = tokio::time::sleep(interval) => {}
-                                res = l.recv() => {
-                                    if let Err(error) = res {
-                                        tracing::warn!(
-                                            policy = %name,
-                                            error = %error,
-                                            "PgListener recv error; falling back to polling"
-                                        );
-                                        listener = None;
+                                changed = leader_rx.changed() => {
+                                    if changed.is_err() {
+                                        break;
                                     }
-                                    // Notification received or listener dropped:
-                                    // proceed to drain immediately.
+                                }
+                                _ = tokio::time::sleep(interval) => {}
+                                res = wake.recv() => {
+                                    // Ok or Lagged both mean "drain now"; Closed
+                                    // means the listener stopped, fall back to polling.
+                                    if let Err(broadcast::error::RecvError::Closed) = res {
+                                        wake_rx = None;
+                                    }
                                 }
                             }
                         } else {
@@ -471,18 +595,21 @@ impl PolicyRunner {
                                         break;
                                     }
                                 }
+                                changed = leader_rx.changed() => {
+                                    if changed.is_err() {
+                                        break;
+                                    }
+                                }
                                 _ = tokio::time::sleep(interval) => {}
                             }
                         }
                     }
 
-                    // Shutdown: explicitly release the lock so a standby can take
-                    // over immediately (without waiting for a TCP session timeout).
-                    let _ = sqlx::query("SELECT pg_advisory_unlock(hashtext($1)::bigint)")
-                        .bind(&name)
-                        .execute(&mut *lock_conn)
-                        .await;
-                    return;
+                    if *policy_shutdown_rx.borrow() {
+                        return;
+                    }
+                    // Lost leadership without shutdown: loop back and wait to be
+                    // re-elected before draining again.
                 }
             }));
         }

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -398,85 +398,139 @@ impl PolicyRunner {
             let pool = self.pool.clone();
             let mut lock_shutdown_rx = shutdown_rx.clone();
             tasks.push(tokio::spawn(async move {
-                // One dedicated connection pinned for the whole tenure. All of this
-                // instance's advisory locks live on this single session.
-                let mut lock_conn = loop {
-                    if *lock_shutdown_rx.borrow() {
-                        return;
-                    }
-                    match pool.acquire().await {
-                        Ok(conn) => break conn,
-                        Err(error) => {
-                            tracing::error!(
-                                error = %error,
-                                "lock manager could not acquire its connection; retrying"
-                            );
-                            tokio::select! {
-                                _ = lock_shutdown_rx.changed() => return,
-                                _ = tokio::time::sleep(interval) => {}
-                            }
+                // Which keys this session currently leads. Preserved across
+                // reconnects so a dropped session revokes exactly what it held.
+                let mut held = vec![false; leadership.len()];
+
+                // Revoke all locally-believed leadership. Used when the pinned
+                // session is lost: Postgres has already released the locks
+                // server-side, so we must stop the workers (set leadership false)
+                // before any standby can also acquire and double-process.
+                let revoke_all = |held: &mut [bool]| {
+                    for (idx, (_name, tx)) in leadership.iter().enumerate() {
+                        if held[idx] {
+                            held[idx] = false;
+                            let _ = tx.send(false);
                         }
                     }
                 };
 
-                // Local record of which keys this session currently holds, so we
-                // only try to acquire keys we are not already leading.
-                let mut held = vec![false; leadership.len()];
-
-                loop {
+                'session: loop {
                     if *lock_shutdown_rx.borrow() {
-                        break;
+                        break 'session;
                     }
 
-                    for (idx, (name, tx)) in leadership.iter().enumerate() {
-                        if held[idx] {
-                            continue;
+                    // (Re)acquire the single pinned connection. All of this
+                    // instance's advisory locks live on this one session; when it
+                    // drops they are all released together, so on reconnect we
+                    // recompete for every key from scratch.
+                    let mut lock_conn = loop {
+                        if *lock_shutdown_rx.borrow() {
+                            return;
                         }
-                        // pg_try_advisory_lock is non-blocking: returns true only
-                        // when this session exclusively holds the lock for `name`.
-                        match sqlx::query_scalar::<_, bool>(
-                            "SELECT pg_try_advisory_lock(hashtext($1)::bigint)",
-                        )
-                        .bind(name)
-                        .fetch_one(&mut *lock_conn)
-                        .await
-                        {
-                            Ok(true) => {
-                                tracing::info!(policy = %name, "acquired advisory lock; leading");
-                                held[idx] = true;
-                                let _ = tx.send(true);
-                            }
-                            Ok(false) => {
-                                tracing::debug!(
-                                    policy = %name,
-                                    "advisory lock held by another instance; standing by"
-                                );
-                            }
+                        match pool.acquire().await {
+                            Ok(conn) => break conn,
                             Err(error) => {
                                 tracing::error!(
-                                    policy = %name,
                                     error = %error,
-                                    "advisory lock query failed"
+                                    "lock manager could not acquire its connection; retrying"
                                 );
+                                tokio::select! {
+                                    _ = lock_shutdown_rx.changed() => return,
+                                    _ = tokio::time::sleep(interval) => {}
+                                }
                             }
                         }
-                    }
+                    };
 
-                    tokio::select! {
-                        _ = lock_shutdown_rx.changed() => break,
-                        _ = tokio::time::sleep(interval) => {}
-                    }
-                }
+                    loop {
+                        if *lock_shutdown_rx.borrow() {
+                            // Clean shutdown: explicitly release every held lock on
+                            // the live connection so a standby can take over
+                            // immediately (without waiting for a TCP session timeout).
+                            for (idx, (name, tx)) in leadership.iter().enumerate() {
+                                if held[idx] {
+                                    let _ = sqlx::query(
+                                        "SELECT pg_advisory_unlock(hashtext($1)::bigint)",
+                                    )
+                                    .bind(name)
+                                    .execute(&mut *lock_conn)
+                                    .await;
+                                    held[idx] = false;
+                                    let _ = tx.send(false);
+                                }
+                            }
+                            break 'session;
+                        }
 
-                // Shutdown: explicitly release every held lock so a standby can
-                // take over immediately (without waiting for a TCP session timeout).
-                for (idx, (name, tx)) in leadership.iter().enumerate() {
-                    if held[idx] {
-                        let _ = sqlx::query("SELECT pg_advisory_unlock(hashtext($1)::bigint)")
+                        // Liveness probe: if we already lead at least one policy,
+                        // verify the pinned session is still alive. A dropped
+                        // session releases ALL our advisory locks server-side, so we
+                        // must revoke leadership locally (stopping the workers before
+                        // a standby can also acquire) and reconnect to recompete.
+                        // This bounds any split-brain window to one poll interval.
+                        if held.iter().any(|h| *h) {
+                            if let Err(error) =
+                                sqlx::query("SELECT 1").execute(&mut *lock_conn).await
+                            {
+                                tracing::warn!(
+                                    error = %error,
+                                    "lock manager connection lost; revoking leadership and reconnecting"
+                                );
+                                revoke_all(&mut held);
+                                continue 'session;
+                            }
+                        }
+
+                        // Try to acquire any keys we do not yet hold.
+                        let mut connection_lost = false;
+                        for (idx, (name, tx)) in leadership.iter().enumerate() {
+                            if held[idx] {
+                                continue;
+                            }
+                            // pg_try_advisory_lock is non-blocking: returns true only
+                            // when this session exclusively holds the lock for `name`.
+                            match sqlx::query_scalar::<_, bool>(
+                                "SELECT pg_try_advisory_lock(hashtext($1)::bigint)",
+                            )
                             .bind(name)
-                            .execute(&mut *lock_conn)
-                            .await;
-                        let _ = tx.send(false);
+                            .fetch_one(&mut *lock_conn)
+                            .await
+                            {
+                                Ok(true) => {
+                                    tracing::info!(policy = %name, "acquired advisory lock; leading");
+                                    held[idx] = true;
+                                    let _ = tx.send(true);
+                                }
+                                Ok(false) => {
+                                    tracing::debug!(
+                                        policy = %name,
+                                        "advisory lock held by another instance; standing by"
+                                    );
+                                }
+                                Err(error) => {
+                                    // A query error may mean the session has dropped:
+                                    // revoke leadership and reconnect rather than
+                                    // continuing to believe we lead the held keys.
+                                    tracing::warn!(
+                                        policy = %name,
+                                        error = %error,
+                                        "advisory lock query failed; reconnecting"
+                                    );
+                                    connection_lost = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if connection_lost {
+                            revoke_all(&mut held);
+                            continue 'session;
+                        }
+
+                        tokio::select! {
+                            _ = lock_shutdown_rx.changed() => {}
+                            _ = tokio::time::sleep(interval) => {}
+                        }
                     }
                 }
             }));

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -2925,6 +2925,170 @@ async fn policy_single_active_runner_via_advisory_lock_postgres_test() {
     daemon_b.shutdown().await;
 }
 
+// ── Bounded connection footprint with many policies (issue #125) ─────────────
+
+/// A policy that reacts to a deposit on a shared *trigger* account by withdrawing
+/// $1 from its own dedicated *target* account. Distinct target streams avoid any
+/// cross-policy write contention, so each registered policy contributes exactly
+/// one `Withdrawn` event when it processes the single trigger deposit.
+struct FootprintPolicy {
+    name: String,
+    target: BankAccountUrn,
+}
+
+impl replay_persistence::Policy for FootprintPolicy {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Now
+    }
+
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        match &event.data {
+            BankAccountEvent::Deposited { operation_date, .. } => {
+                vec![replay_persistence::Dispatch::to::<BankAccount>(
+                    self.target.clone(),
+                    BankAccountCommand::Withdraw {
+                        effective_on: *operation_date,
+                        amount: 1.0,
+                    },
+                )]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// Many registered policies share a bounded connection pool without starving.
+///
+/// Regression test for issue #125: the previous `start_polling` pinned **two**
+/// connections per policy (a dedicated advisory-lock connection plus a dedicated
+/// `PgListener` connection) for the whole leadership tenure, i.e. `O(2P)`. With
+/// more policies than `max_connections / 2`, later policies could never acquire
+/// their connections and silently stopped processing — the symptom reported as a
+/// "database connection pool timed out" in the consuming app.
+///
+/// The current design holds a **constant** number of pinned connections
+/// regardless of policy count (one shared lock manager + one shared listener), so
+/// every policy makes progress even on a pool far smaller than `2P`.
+///
+/// Scenario:
+///   1. A small pool (`max_connections = 8`) backs a single runner with **12**
+///      policies — well above `8 / 2 = 4`, so the old design would starve most.
+///   2. Each policy's target account is seeded with a deposit *before* the daemon
+///      starts, so `StartAt::Now` skips the seeds.
+///   3. One deposit is appended to the shared trigger account after the daemon is
+///      leading. Every policy reacts once → exactly 12 `Withdrawn` events.
+#[tokio::test]
+async fn policy_bounded_connection_footprint_many_policies_postgres_test() {
+    use std::time::Duration;
+
+    const POLICY_COUNT: usize = 12;
+
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    // Deliberately small pool: 8 connections for 12 policies. The old per-policy
+    // design needed 24 pinned connections and would starve; the shared design
+    // pins only ~2.
+    let pg_pool = PgPoolOptions::new()
+        .max_connections(8)
+        .acquire_timeout(Duration::from_secs(4))
+        .connect(&format!(
+            "postgres://postgres:postgres@{}:{}/postgres",
+            host, port
+        ))
+        .await
+        .expect("Failed to create bounded postgres pool");
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let meta = replay::Metadata::default();
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+
+    // ── Seed each policy's target account with a balance to withdraw from ──────
+    // These deposits happen before the daemon starts so `StartAt::Now` skips them.
+    let targets: Vec<BankAccountUrn> = (0..POLICY_COUNT)
+        .map(|i| BankAccountUrn::new(format!("footprint-target-{i}")).unwrap())
+        .collect();
+
+    for target in &targets {
+        cqrs.execute::<BankAccount>(
+            target,
+            meta.clone(),
+            BankAccountCommand::Deposit {
+                effective_on: date,
+                amount: 100.0,
+            },
+            &(),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    // ── Build a single runner with all 12 policies and start it ───────────────
+    let mut builder = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(());
+    for (i, target) in targets.iter().enumerate() {
+        builder = builder.register_policy(FootprintPolicy {
+            name: format!("footprint_policy_{i}"),
+            target: target.clone(),
+        });
+    }
+    let daemon = builder.build().start_polling(Duration::from_millis(50));
+
+    // Give the shared lock manager time to elect every policy as leader and let
+    // each worker capture its `StartAt::Now` cursor past the seed deposits.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // ── Append one deposit to the shared trigger account ──────────────────────
+    let trigger = BankAccountUrn::new("footprint-trigger").unwrap();
+    cqrs.execute::<BankAccount>(
+        &trigger,
+        meta.clone(),
+        BankAccountCommand::Deposit {
+            effective_on: date,
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Allow every policy to drain the single trigger event. A constrained pool
+    // serializes the transient drains, so give a generous window.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let withdrawn =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM events WHERE type = 'Withdrawn'")
+            .fetch_one(&pg_pool)
+            .await
+            .expect("count query must succeed");
+
+    assert_eq!(
+        withdrawn, POLICY_COUNT as i64,
+        "every one of the {POLICY_COUNT} policies must process the trigger deposit on a pool \
+         far smaller than 2x the policy count; the old O(2P) design would starve most of them"
+    );
+
+    daemon.shutdown().await;
+}
+
 // ── Loop prevention via causation-depth limit (issue #83) ────────────────────
 
 /// A policy that deliberately creates a loop: every `Deposited` event triggers

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -3051,9 +3051,27 @@ async fn policy_bounded_connection_footprint_many_policies_postgres_test() {
     }
     let daemon = builder.build().start_polling(Duration::from_millis(50));
 
-    // Give the shared lock manager time to elect every policy as leader and let
-    // each worker capture its `StartAt::Now` cursor past the seed deposits.
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    // Wait until every policy has persisted its `StartAt::Now` cursor before
+    // appending the trigger. `load_cursor` inserts the cursor row at bootstrap,
+    // so the presence of all rows proves every worker captured `Now` ahead of the
+    // trigger and cannot initialize after it and legitimately skip it.
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        let ready = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM policy_cursors WHERE name LIKE 'footprint_policy_%'",
+        )
+        .fetch_one(&pg_pool)
+        .await
+        .expect("cursor count query must succeed");
+        if ready == POLICY_COUNT as i64 {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "only {ready}/{POLICY_COUNT} policy cursors initialized before timeout"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 
     // ── Append one deposit to the shared trigger account ──────────────────────
     let trigger = BankAccountUrn::new("footprint-trigger").unwrap();
@@ -3070,15 +3088,25 @@ async fn policy_bounded_connection_footprint_many_policies_postgres_test() {
     .await
     .unwrap();
 
-    // Allow every policy to drain the single trigger event. A constrained pool
-    // serializes the transient drains, so give a generous window.
-    tokio::time::sleep(Duration::from_millis(1500)).await;
-
-    let withdrawn =
-        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM events WHERE type = 'Withdrawn'")
-            .fetch_one(&pg_pool)
-            .await
-            .expect("count query must succeed");
+    // Poll until every policy has drained the trigger event rather than relying
+    // on a fixed delay; a constrained pool serializes the transient drains and a
+    // slow or contended host can take a while.
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let withdrawn = loop {
+        let count =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM events WHERE type = 'Withdrawn'")
+                .fetch_one(&pg_pool)
+                .await
+                .expect("count query must succeed");
+        if count >= POLICY_COUNT as i64 {
+            break count;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "only {count}/{POLICY_COUNT} policies processed the trigger deposit before timeout"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
 
     assert_eq!(
         withdrawn, POLICY_COUNT as i64,


### PR DESCRIPTION
Fixes #125.

## Problem

`PolicyRunner::start_polling` spawned one task per policy, and each task pinned **two** connections for its whole leadership tenure: a dedicated advisory-lock connection plus a dedicated `PgListener` connection. With `P` policies that is `O(2P)` permanently-held connections. Once `2P` exceeds the shared SQLx pool's `max_connections`, later policies can never acquire their connections and silently stop processing — the symptom reported in the consuming app as *"database connection pool timed out"*.

## Fix

Replace the per-policy connection model with shared per-process infrastructure:

- **One shared lock-manager task** holds a single connection and acquires every policy's `pg_advisory_lock` on it (Postgres session locks are per-session and one session may hold many keys). It publishes per-policy leadership on a `watch` channel and releases the held locks on shutdown so a standby takes over immediately.
- **One shared `PgListener` task** holds a single connection and fans each `NOTIFY` out to all workers via a `tokio::broadcast` channel. A lagged or missed wakeup is harmless — workers still wake on the poll interval (NOTIFY stays a best-effort latency hint per ADR-0003).
- **Per-policy worker tasks** hold no pinned connection; they wait for leadership, load their cursor, and drain with transient pooled connections only.

Steady-state pinned connections are now **constant (~2)** regardless of policy count.

## Preserved guarantees / trade-off

- Single-leader-per-policy, per-policy leadership, and shutdown-triggered failover are all preserved.
- **Trade-off:** failover granularity is now coarser — a single instance's policies fail over together when its lock connection drops. Each policy is still recovered independently and exactly once. Documented in **ADR-0008**.

## Tests

- New `policy_bounded_connection_footprint_many_policies_postgres_test`: 12 policies on an 8-connection pool (old design needed 24) all process the trigger event.
- All 24 existing `policy_*` integration tests pass (single-active-runner failover, NOTIFY-wakes-before-interval, without-notifications polling, dead-letter, status).

No schema change.
