### PR TITLE
feat(persistence): retry_dead_letter primitive with full row lifecycle

### DIFF
--- a/persistence/src/lib.rs
+++ b/persistence/src/lib.rs
@@ -20,7 +20,7 @@ pub use inline_projection::InlineProjection;
 pub use persisted_event::PersistedEvent;
 pub use policy::{Dispatch, Policy, StartAt};
 pub use policy_runner::{
-    PolicyRunner, PolicyRunnerBuilder, PolicyRunnerDaemon, REPLAY_NOTIFY_CHANNEL,
+    DeadLetterRetry, PolicyRunner, PolicyRunnerBuilder, PolicyRunnerDaemon, REPLAY_NOTIFY_CHANNEL,
 };
 pub use policy_status::{PolicyCondition, PolicyStatus, PolicyStatusStore};
 pub use query::Query;
@@ -45,9 +45,9 @@ pub mod prelude {
 
     // Persistence types from this crate
     pub use super::{
-        AggregateVersion, Cqrs, Dispatch, EventSink, EventStore, InMemoryEventStore,
-        InlineProjection, NoSink, PersistedEvent, Policy, PolicyCondition, PolicyRunner,
-        PolicyRunnerBuilder, PolicyRunnerDaemon, PolicyStatus, PolicyStatusStore,
+        AggregateVersion, Cqrs, DeadLetterRetry, Dispatch, EventSink, EventStore,
+        InMemoryEventStore, InlineProjection, NoSink, PersistedEvent, Policy, PolicyCondition,
+        PolicyRunner, PolicyRunnerBuilder, PolicyRunnerDaemon, PolicyStatus, PolicyStatusStore,
         PostgresEventStore, PostgresInlineProjection, Query, StartAt, StreamFilter,
     };
 }

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -390,7 +390,7 @@ impl PolicyRunner {
             Some(error) => {
                 sqlx::query(
                     "UPDATE policy_dead_letters \
-                     SET error_kind = $2, error_message = $3, created_at = now() \
+                     SET error_kind = $2, error_message = $3 \
                      WHERE id = $1",
                 )
                 .bind(id)

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -212,6 +212,19 @@ impl PolicyRunnerBuilder {
     }
 }
 
+/// Outcome of [`PolicyRunner::retry_dead_letter`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeadLetterRetry {
+    /// The reaction succeeded, or the aggregate now declines it with a
+    /// `BusinessRuleViolation`: the dead-letter row was deleted.
+    Resolved,
+    /// The reaction failed permanently again: the existing row was updated in
+    /// place with the fresh error. No second row was ever inserted.
+    StillFailing,
+    /// No dead-letter row matched the supplied id: nothing to do.
+    NotFound,
+}
+
 /// Native runner that drives registered policies against the event feed.
 pub struct PolicyRunner {
     cqrs: Cqrs<PostgresEventStore>,
@@ -264,6 +277,131 @@ impl PolicyRunner {
             total += self.drain_policy(policy.as_ref()).await?;
         }
         Ok(total)
+    }
+
+    /// Re-run a single parked dead letter's reaction against current state.
+    ///
+    /// Loads the dead-letter row `id`, looks up its owning policy by name,
+    /// reloads the triggering event it pinned, and replays the policy's pure
+    /// reaction through the same [`Cqrs`] path the live drain uses — taking no
+    /// advisory lock and never touching `policy_cursors`. The row is then
+    /// settled **after** execution:
+    ///
+    /// - the reaction succeeds, or the aggregate now declines it with a
+    ///   `BusinessRuleViolation` → the row is **deleted**
+    ///   ([`DeadLetterRetry::Resolved`]).
+    /// - the reaction fails permanently again → the existing row is **updated
+    ///   in place** with the fresh error ([`DeadLetterRetry::StillFailing`]);
+    ///   no second row is ever inserted.
+    ///
+    /// Re-execution safety comes from the causation guard (the command carries
+    /// the triggering event's id) plus the optimistic-concurrency check in
+    /// [`Cqrs::execute`], so retrying an already-applied reaction is a no-op.
+    ///
+    /// Returns [`DeadLetterRetry::NotFound`] when no row matches `id`. Returns a
+    /// clear error (never panics) when the dead letter's policy is not
+    /// registered on this runner, when a reproduced dispatch targets an
+    /// aggregate whose services are not registered, or when the pinned
+    /// triggering event can no longer be found.
+    pub async fn retry_dead_letter(&self, id: i64) -> Result<DeadLetterRetry, replay::Error> {
+        let Some(row) = sqlx::query(
+            "SELECT policy_name, global_position, event_id \
+             FROM policy_dead_letters WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(crate::db_error)?
+        else {
+            return Ok(DeadLetterRetry::NotFound);
+        };
+
+        let policy_name: String = row.get("policy_name");
+        let global_position: i64 = row.get("global_position");
+        let event_id: uuid::Uuid = row.get("event_id");
+
+        let policy = self
+            .policies
+            .iter()
+            .find(|p| p.name() == policy_name)
+            .ok_or_else(|| {
+                replay::Error::invalid_input(
+                    "no registered policy matches the dead letter's policy_name",
+                )
+                .with_operation("retry_dead_letter")
+                .with_context("policy", &policy_name)
+            })?;
+
+        let raw = load_event_by_id(&self.pool, event_id)
+            .await?
+            .ok_or_else(|| {
+                replay::Error::not_found("triggering event for dead letter no longer exists")
+                    .with_operation("retry_dead_letter")
+                    .with_context("policy", &policy_name)
+                    .with_context("event_id", event_id)
+            })?;
+
+        // Reproduce and execute every dispatch the reaction now yields. A missing
+        // executor is an operator misconfiguration (a clear error to the caller),
+        // distinct from a dispatch that executes but fails permanently (which
+        // re-parks the row in place).
+        let mut failure: Option<replay::Error> = None;
+        for dispatch in policy.react_erased(&raw) {
+            if !self.executors.contains_key(&dispatch.target()) {
+                return Err(replay::Error::invalid_input(
+                    "no services registered for the aggregate targeted by a policy dispatch",
+                )
+                .with_operation("retry_dead_letter")
+                .with_context("policy", &policy_name)
+                .with_context("aggregate", dispatch.aggregate_name()));
+            }
+
+            match execute_dispatch(
+                &self.cqrs,
+                &self.executors,
+                &policy_name,
+                global_position,
+                &raw,
+                dispatch,
+            )
+            .await
+            {
+                Ok(()) => {}
+                Err(e) if e.kind() == replay::ErrorKind::BusinessRuleViolation => {
+                    // Stale reaction: the aggregate now declines it. Clean
+                    // resolution — fall through to delete the row.
+                }
+                Err(e) => {
+                    failure = Some(e);
+                    break;
+                }
+            }
+        }
+
+        match failure {
+            None => {
+                sqlx::query("DELETE FROM policy_dead_letters WHERE id = $1")
+                    .bind(id)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(crate::db_error)?;
+                Ok(DeadLetterRetry::Resolved)
+            }
+            Some(error) => {
+                sqlx::query(
+                    "UPDATE policy_dead_letters \
+                     SET error_kind = $2, error_message = $3, created_at = now() \
+                     WHERE id = $1",
+                )
+                .bind(id)
+                .bind(error.kind().to_string())
+                .bind(error.to_string())
+                .execute(&self.pool)
+                .await
+                .map_err(crate::db_error)?;
+                Ok(DeadLetterRetry::StillFailing)
+            }
+        }
     }
 
     /// Start one long-lived polling task per registered policy.
@@ -694,6 +832,27 @@ async fn write_dead_letter(
     .await
     .map_err(crate::db_error)?;
     Ok(())
+}
+
+/// Load a single event by its primary key, shaped exactly like [`read_feed`]
+/// so it can be fed back into a policy's erased reaction during retry.
+async fn load_event_by_id(
+    pool: &Pool<Postgres>,
+    event_id: uuid::Uuid,
+) -> Result<Option<PersistedEvent<Value>>, replay::Error> {
+    let row = sqlx::query(
+        "SELECT id, data, metadata, stream_id, type, version, created, aggregate_version, \
+         global_position, compacted_snapshot FROM events WHERE id = $1",
+    )
+    .bind(event_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(crate::db_error)?;
+
+    match row {
+        Some(row) => Ok(Some(PersistedEvent::<Value>::try_from(row)?)),
+        None => Ok(None),
+    }
 }
 
 /// Read the contiguous, gap-free prefix of events with `global_position >

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -3292,6 +3292,501 @@ async fn policy_business_rule_violation_advances_without_dead_letter_postgres_te
     assert_eq!(cursor, 1, "cursor must have advanced past the BRV event");
 }
 
+// ── Dead-letter retry: retry_dead_letter primitive (issue #126) ───────────────
+
+// An aggregate whose command handler always fails with a permanent,
+// non-retryable, non-BusinessRuleViolation error.  Used to manufacture a
+// dead letter whose retry fails again, exercising the update-in-place path.
+define_aggregate! {
+    AlwaysFailsAccount {
+        namespace: "always-fails-account",
+        state: {
+            touched: bool,
+        },
+        commands: {
+            Touch { nonce: u64 },
+        },
+        events: {
+            Touched { nonce: u64 },
+        }
+    }
+}
+
+impl replay::EventStream for AlwaysFailsAccount {
+    type Event = AlwaysFailsAccountEvent;
+
+    fn stream_type() -> String {
+        "AlwaysFailsAccount".to_string()
+    }
+
+    fn apply(&mut self, event: Self::Event) {
+        match event {
+            AlwaysFailsAccountEvent::Touched { .. } => self.touched = true,
+        }
+    }
+}
+
+impl replay::Aggregate for AlwaysFailsAccount {
+    type Command = AlwaysFailsAccountCommand;
+    type Error = replay::Error;
+    type Services = ();
+
+    async fn handle(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        let AlwaysFailsAccountCommand::Touch { .. } = command;
+        Err(
+            replay::Error::invalid_input("always-fails-account rejects every command")
+                .with_operation("Touch"),
+        )
+    }
+}
+
+/// Reacts to each deposit by charging a causation-guarded fee against a fixed
+/// `IdempotentFeeAccount`.  Re-running the reaction is safe: the aggregate
+/// absorbs a duplicate causation id as a no-op.
+struct RetryFeePolicy {
+    target: IdempotentFeeAccountUrn,
+    fee: f64,
+}
+
+impl replay_persistence::Policy for RetryFeePolicy {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "retry_fee_policy"
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Beginning
+    }
+
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        match &event.data {
+            BankAccountEvent::Deposited { .. } => {
+                vec![replay_persistence::Dispatch::to::<IdempotentFeeAccount>(
+                    self.target.clone(),
+                    IdempotentFeeAccountCommand::ChargeFee {
+                        amount: self.fee,
+                        causation_event_id: event.id,
+                    },
+                )]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// Reacts to each deposit by dispatching a `Touch` to `AlwaysFailsAccount`,
+/// which always fails permanently.
+struct AlwaysFailsPolicy {
+    target: AlwaysFailsAccountUrn,
+}
+
+impl replay_persistence::Policy for AlwaysFailsPolicy {
+    type Event = BankAccountEvent;
+
+    fn name(&self) -> &str {
+        "always_fails_policy"
+    }
+
+    fn start_at(&self) -> replay_persistence::StartAt {
+        replay_persistence::StartAt::Beginning
+    }
+
+    fn react(&self, event: &PersistedEvent<Self::Event>) -> Vec<replay_persistence::Dispatch> {
+        match &event.data {
+            BankAccountEvent::Deposited { .. } => {
+                vec![replay_persistence::Dispatch::to::<AlwaysFailsAccount>(
+                    self.target.clone(),
+                    AlwaysFailsAccountCommand::Touch { nonce: 1 },
+                )]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// Append a single deposit and manufacture one dead letter for `policy` by
+/// draining a runner that does **not** register the aggregate the policy
+/// dispatches to (so the dispatch fails permanently with `InvalidInput`).
+///
+/// Returns `(pool, cqrs, dead_letter_id)`.
+async fn manufacture_dead_letter<P>(
+    policy: P,
+    policy_name: &str,
+) -> (
+    PgPool,
+    replay_persistence::Cqrs<replay_persistence::PostgresEventStore>,
+    i64,
+)
+where
+    P: replay_persistence::Policy + 'static,
+{
+    let container = postgres::Postgres::default().start().await.unwrap();
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(POSTGRES_PORT)
+        .await
+        .expect("Error getting docker port");
+    // Keep the container alive for the duration of the test by leaking it; the
+    // process exit reclaims it.  (Mirrors the lifetime needs of these tests.)
+    std::mem::forget(container);
+    let pg_pool = connect_to_postgres(host, port).await;
+
+    sqlx::migrate!("./tests/migrations")
+        .run(&pg_pool)
+        .await
+        .expect("Failed to run migrations");
+
+    let store = replay_persistence::PostgresEventStore::new(pg_pool.clone());
+    let cqrs = replay_persistence::Cqrs::new(store);
+    let account = BankAccountUrn::new("retry-trigger").unwrap();
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+
+    cqrs.execute::<BankAccount>(
+        &account,
+        replay::Metadata::default(),
+        BankAccountCommand::Deposit {
+            effective_on: date,
+            amount: 100.0,
+        },
+        &(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Manufacturing runner: the policy is registered but the dispatch target's
+    // services are NOT, so the dispatch dead-letters.
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_policy(policy)
+        .build();
+    runner
+        .drain()
+        .await
+        .expect("manufacturing drain must not error");
+
+    let id: i64 = sqlx::query_scalar("SELECT id FROM policy_dead_letters WHERE policy_name = $1")
+        .bind(policy_name)
+        .fetch_one(&pg_pool)
+        .await
+        .expect("exactly one dead letter must exist");
+
+    (pg_pool, cqrs, id)
+}
+
+async fn policy_condition(pool: &PgPool, name: &str) -> replay_persistence::PolicyCondition {
+    replay_persistence::PolicyStatusStore::new(pool.clone())
+        .list()
+        .await
+        .expect("status list must succeed")
+        .into_iter()
+        .find(|s| s.name == name)
+        .unwrap_or_else(|| panic!("no status row for policy {name}"))
+        .condition
+}
+
+async fn dead_letter_count(pool: &PgPool, name: &str) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM policy_dead_letters WHERE policy_name = $1")
+        .bind(name)
+        .fetch_one(pool)
+        .await
+        .expect("dead-letter count query must succeed")
+}
+
+/// Retry succeeds: the reproduced reaction applies exactly once, the row is
+/// deleted, the policy is no longer `Degraded`, the cursor is untouched, and no
+/// advisory lock is ever taken (the polling daemon is never started).
+#[tokio::test]
+async fn retry_dead_letter_resolves_and_deletes_row_postgres_test() {
+    let target = IdempotentFeeAccountUrn::new("retry-success-target").unwrap();
+    let (pg_pool, cqrs, id) = manufacture_dead_letter(
+        RetryFeePolicy {
+            target: target.clone(),
+            fee: 5.0,
+        },
+        "retry_fee_policy",
+    )
+    .await;
+
+    assert_eq!(dead_letter_count(&pg_pool, "retry_fee_policy").await, 1);
+    assert_eq!(
+        policy_condition(&pg_pool, "retry_fee_policy").await,
+        replay_persistence::PolicyCondition::Degraded,
+        "a parked dead letter must read as Degraded"
+    );
+
+    let cursor_before: i64 =
+        sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = 'retry_fee_policy'")
+            .fetch_one(&pg_pool)
+            .await
+            .unwrap();
+
+    // Retry runner: registers the missing aggregate so the reproduced dispatch
+    // can apply.  The polling daemon is intentionally never started.
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<IdempotentFeeAccount>(())
+        .register_policy(RetryFeePolicy {
+            target: target.clone(),
+            fee: 5.0,
+        })
+        .build();
+
+    let outcome = runner
+        .retry_dead_letter(id)
+        .await
+        .expect("retry must not error");
+    assert_eq!(outcome, replay_persistence::DeadLetterRetry::Resolved);
+
+    // Row deleted.
+    assert_eq!(dead_letter_count(&pg_pool, "retry_fee_policy").await, 0);
+
+    // Reaction applied exactly once (balance reflects a single fee charge).
+    let account = cqrs
+        .fetch_aggregate::<IdempotentFeeAccount>(&target)
+        .await
+        .unwrap();
+    assert_eq!(
+        account.balance, -5.0,
+        "exactly one fee must have been charged"
+    );
+
+    // Policy recovered: no longer Degraded.
+    assert_ne!(
+        policy_condition(&pg_pool, "retry_fee_policy").await,
+        replay_persistence::PolicyCondition::Degraded,
+        "after a successful retry the policy must no longer be Degraded"
+    );
+
+    // Cursor untouched.
+    let cursor_after: i64 =
+        sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = 'retry_fee_policy'")
+            .fetch_one(&pg_pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        cursor_before, cursor_after,
+        "retry must not move the cursor"
+    );
+
+    // No advisory lock taken: retry needs no leadership.
+    let advisory_locks: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory'")
+            .fetch_one(&pg_pool)
+            .await
+            .unwrap();
+    assert_eq!(advisory_locks, 0, "retry must not acquire an advisory lock");
+}
+
+/// Retry still failing: the row is updated in place (count stays 1, never 2)
+/// and the policy stays `Degraded`.
+#[tokio::test]
+async fn retry_dead_letter_still_failing_updates_row_in_place_postgres_test() {
+    let target = AlwaysFailsAccountUrn::new("retry-fail-target").unwrap();
+    let (pg_pool, cqrs, id) = manufacture_dead_letter(
+        AlwaysFailsPolicy {
+            target: target.clone(),
+        },
+        "always_fails_policy",
+    )
+    .await;
+
+    assert_eq!(dead_letter_count(&pg_pool, "always_fails_policy").await, 1);
+
+    // Retry runner registers the failing aggregate, so the dispatch executes
+    // and fails again permanently.
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<AlwaysFailsAccount>(())
+        .register_policy(AlwaysFailsPolicy {
+            target: target.clone(),
+        })
+        .build();
+
+    let outcome = runner
+        .retry_dead_letter(id)
+        .await
+        .expect("retry must not error");
+    assert_eq!(outcome, replay_persistence::DeadLetterRetry::StillFailing);
+
+    // Updated in place: still exactly one row, same id.
+    assert_eq!(
+        dead_letter_count(&pg_pool, "always_fails_policy").await,
+        1,
+        "a still-failing retry must update in place, never insert a second row"
+    );
+    let surviving_id: i64 = sqlx::query_scalar(
+        "SELECT id FROM policy_dead_letters WHERE policy_name = 'always_fails_policy'",
+    )
+    .fetch_one(&pg_pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        surviving_id, id,
+        "the same row must be updated, not replaced"
+    );
+
+    assert_eq!(
+        policy_condition(&pg_pool, "always_fails_policy").await,
+        replay_persistence::PolicyCondition::Degraded,
+        "a still-failing policy stays Degraded"
+    );
+}
+
+/// Retry now stale: the aggregate declines the reproduced command with a
+/// `BusinessRuleViolation`, which is a clean resolution — the row is deleted and
+/// the policy recovers.
+#[tokio::test]
+async fn retry_dead_letter_stale_reaction_resolves_postgres_test() {
+    // `InsufficientFundsPolicy` withdraws $999 999 from the deposit's own
+    // account.  Manufactured against an unregistered `BankAccount`, it
+    // dead-letters; on retry against the (balance $100) account it is declined
+    // with a BusinessRuleViolation.
+    let (pg_pool, cqrs, id) =
+        manufacture_dead_letter(InsufficientFundsPolicy, "insufficient_funds_policy").await;
+
+    assert_eq!(
+        dead_letter_count(&pg_pool, "insufficient_funds_policy").await,
+        1
+    );
+
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<BankAccount>(())
+        .register_policy(InsufficientFundsPolicy)
+        .build();
+
+    let outcome = runner
+        .retry_dead_letter(id)
+        .await
+        .expect("retry must not error");
+    assert_eq!(
+        outcome,
+        replay_persistence::DeadLetterRetry::Resolved,
+        "a BusinessRuleViolation on retry is a clean resolution"
+    );
+
+    assert_eq!(
+        dead_letter_count(&pg_pool, "insufficient_funds_policy").await,
+        0,
+        "a stale (BRV) reaction must delete the dead letter"
+    );
+    assert_ne!(
+        policy_condition(&pg_pool, "insufficient_funds_policy").await,
+        replay_persistence::PolicyCondition::Degraded,
+        "after a stale-resolution retry the policy must recover"
+    );
+}
+
+/// Retry is idempotent: replaying the same id twice applies the reaction at
+/// most once and the row ends deleted.
+#[tokio::test]
+async fn retry_dead_letter_is_idempotent_postgres_test() {
+    let target = IdempotentFeeAccountUrn::new("retry-idempotent-target").unwrap();
+    let (pg_pool, cqrs, id) = manufacture_dead_letter(
+        RetryFeePolicy {
+            target: target.clone(),
+            fee: 7.0,
+        },
+        "retry_fee_policy",
+    )
+    .await;
+
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<IdempotentFeeAccount>(())
+        .register_policy(RetryFeePolicy {
+            target: target.clone(),
+            fee: 7.0,
+        })
+        .build();
+
+    let first = runner
+        .retry_dead_letter(id)
+        .await
+        .expect("first retry must not error");
+    assert_eq!(first, replay_persistence::DeadLetterRetry::Resolved);
+
+    // Second retry of the same id: the row is already gone — a defined no-op.
+    let second = runner
+        .retry_dead_letter(id)
+        .await
+        .expect("second retry must not error");
+    assert_eq!(second, replay_persistence::DeadLetterRetry::NotFound);
+
+    // Reaction applied at most once.
+    let account = cqrs
+        .fetch_aggregate::<IdempotentFeeAccount>(&target)
+        .await
+        .unwrap();
+    assert_eq!(
+        account.balance, -7.0,
+        "the fee must be charged at most once"
+    );
+
+    assert_eq!(
+        dead_letter_count(&pg_pool, "retry_fee_policy").await,
+        0,
+        "the row must end deleted"
+    );
+}
+
+/// Error contract: an unregistered policy name and a dispatch targeting an
+/// unregistered aggregate both return a clear error; an absent id is a defined
+/// no-op (`NotFound`).
+#[tokio::test]
+async fn retry_dead_letter_error_contract_postgres_test() {
+    let target = IdempotentFeeAccountUrn::new("retry-error-target").unwrap();
+    let (pg_pool, cqrs, id) = manufacture_dead_letter(
+        RetryFeePolicy {
+            target: target.clone(),
+            fee: 3.0,
+        },
+        "retry_fee_policy",
+    )
+    .await;
+
+    // (a) Absent id → defined no-op.
+    let runner_full = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<IdempotentFeeAccount>(())
+        .register_policy(RetryFeePolicy {
+            target: target.clone(),
+            fee: 3.0,
+        })
+        .build();
+    let absent = runner_full
+        .retry_dead_letter(999_999)
+        .await
+        .expect("absent id must not error");
+    assert_eq!(absent, replay_persistence::DeadLetterRetry::NotFound);
+
+    // (b) Policy name not registered on this runner → clear error.
+    let runner_no_policy = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_services::<IdempotentFeeAccount>(())
+        .build();
+    let err = runner_no_policy
+        .retry_dead_letter(id)
+        .await
+        .expect_err("unregistered policy must return an error");
+    assert_eq!(err.kind(), replay::ErrorKind::InvalidInput);
+
+    // (c) Dispatch targets an unregistered aggregate → clear error.
+    let runner_no_aggregate = replay_persistence::PolicyRunner::builder(cqrs.clone())
+        .register_policy(RetryFeePolicy {
+            target: target.clone(),
+            fee: 3.0,
+        })
+        .build();
+    let err = runner_no_aggregate
+        .retry_dead_letter(id)
+        .await
+        .expect_err("unregistered aggregate must return an error");
+    assert_eq!(err.kind(), replay::ErrorKind::InvalidInput);
+
+    // The row is untouched by the failed attempts.
+    assert_eq!(dead_letter_count(&pg_pool, "retry_fee_policy").await, 1);
+}
+
 // ── Batching: read-batch size and checkpoint-batch size (issue #85) ───────────
 
 /// Policy with a custom read-batch size for testing.

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -3610,6 +3610,7 @@ async fn manufacture_dead_letter<P>(
     policy: P,
     policy_name: &str,
 ) -> (
+    testcontainers_modules::testcontainers::ContainerAsync<postgres::Postgres>,
     PgPool,
     replay_persistence::Cqrs<replay_persistence::PostgresEventStore>,
     i64,
@@ -3623,9 +3624,6 @@ where
         .get_host_port_ipv4(POSTGRES_PORT)
         .await
         .expect("Error getting docker port");
-    // Keep the container alive for the duration of the test by leaking it; the
-    // process exit reclaims it.  (Mirrors the lifetime needs of these tests.)
-    std::mem::forget(container);
     let pg_pool = connect_to_postgres(host, port).await;
 
     sqlx::migrate!("./tests/migrations")
@@ -3667,7 +3665,7 @@ where
         .await
         .expect("exactly one dead letter must exist");
 
-    (pg_pool, cqrs, id)
+    (container, pg_pool, cqrs, id)
 }
 
 async fn policy_condition(pool: &PgPool, name: &str) -> replay_persistence::PolicyCondition {
@@ -3695,7 +3693,7 @@ async fn dead_letter_count(pool: &PgPool, name: &str) -> i64 {
 #[tokio::test]
 async fn retry_dead_letter_resolves_and_deletes_row_postgres_test() {
     let target = IdempotentFeeAccountUrn::new("retry-success-target").unwrap();
-    let (pg_pool, cqrs, id) = manufacture_dead_letter(
+    let (_container, pg_pool, cqrs, id) = manufacture_dead_letter(
         RetryFeePolicy {
             target: target.clone(),
             fee: 5.0,
@@ -3778,7 +3776,7 @@ async fn retry_dead_letter_resolves_and_deletes_row_postgres_test() {
 #[tokio::test]
 async fn retry_dead_letter_still_failing_updates_row_in_place_postgres_test() {
     let target = AlwaysFailsAccountUrn::new("retry-fail-target").unwrap();
-    let (pg_pool, cqrs, id) = manufacture_dead_letter(
+    let (_container, pg_pool, cqrs, id) = manufacture_dead_letter(
         AlwaysFailsPolicy {
             target: target.clone(),
         },
@@ -3836,7 +3834,7 @@ async fn retry_dead_letter_stale_reaction_resolves_postgres_test() {
     // account.  Manufactured against an unregistered `BankAccount`, it
     // dead-letters; on retry against the (balance $100) account it is declined
     // with a BusinessRuleViolation.
-    let (pg_pool, cqrs, id) =
+    let (_container, pg_pool, cqrs, id) =
         manufacture_dead_letter(InsufficientFundsPolicy, "insufficient_funds_policy").await;
 
     assert_eq!(
@@ -3876,7 +3874,7 @@ async fn retry_dead_letter_stale_reaction_resolves_postgres_test() {
 #[tokio::test]
 async fn retry_dead_letter_is_idempotent_postgres_test() {
     let target = IdempotentFeeAccountUrn::new("retry-idempotent-target").unwrap();
-    let (pg_pool, cqrs, id) = manufacture_dead_letter(
+    let (_container, pg_pool, cqrs, id) = manufacture_dead_letter(
         RetryFeePolicy {
             target: target.clone(),
             fee: 7.0,
@@ -3929,7 +3927,7 @@ async fn retry_dead_letter_is_idempotent_postgres_test() {
 #[tokio::test]
 async fn retry_dead_letter_error_contract_postgres_test() {
     let target = IdempotentFeeAccountUrn::new("retry-error-target").unwrap();
-    let (pg_pool, cqrs, id) = manufacture_dead_letter(
+    let (_container, pg_pool, cqrs, id) = manufacture_dead_letter(
         RetryFeePolicy {
             target: target.clone(),
             fee: 3.0,


### PR DESCRIPTION
## Summary

Implements `PolicyRunner::retry_dead_letter(id)` (issue #126) — the core operator primitive that re-runs a single parked dead letter's reaction against the world as it is now.

Given a dead-letter id, it:
1. loads the triggering event the row pinned (`event_id`),
2. looks up the owning policy by `policy_name`,
3. replays the policy's pure `react` to reproduce the `Dispatch`,
4. executes it through the same `Cqrs` path the live drain uses,

then **executes first, then mutates the row by primary key**:

- `Ok` *or* `BusinessRuleViolation` (stale) → `DELETE` the row (`DeadLetterRetry::Resolved`).
- repeat permanent failure → `UPDATE` the existing row in place with the fresh error (`DeadLetterRetry::StillFailing`); never inserts a second row.

Per ADR-0007, retry takes **no advisory lock** and **never touches `policy_cursors`**. Re-execution safety comes from the existing causation guard plus the optimistic-concurrency check in `Cqrs::execute`. No schema change to `policy_dead_letters`.

## API

- `PolicyRunner::retry_dead_letter(&self, id: i64) -> Result<DeadLetterRetry, replay::Error>`
- New public `DeadLetterRetry { Resolved, StillFailing, NotFound }` (exported next to `PolicyRunner`, also in the prelude).

## Error contract

- absent id → `Ok(DeadLetterRetry::NotFound)` (defined no-op).
- unregistered policy name → clear `InvalidInput` error (no panic).
- dispatch targeting an unregistered aggregate → clear `InvalidInput` error (no panic), distinct from an executed-but-failing dispatch.

## Tests

Docker-gated Postgres integration tests that manufacture real dead letters via `drain()` and assert through `PolicyStatusStore::list()`, mirroring `policy_permanent_failure_is_dead_lettered_and_advances_postgres_test`:

- `retry_dead_letter_resolves_and_deletes_row` — success: applied exactly once, row deleted, no longer `Degraded`, cursor untouched, no advisory lock taken (daemon never started).
- `retry_dead_letter_still_failing_updates_row_in_place` — count stays 1 (same row id), stays `Degraded`.
- `retry_dead_letter_stale_reaction_resolves` — BRV on retry → row deleted, recovers.
- `retry_dead_letter_is_idempotent` — two retries apply the reaction at most once; row ends deleted.
- `retry_dead_letter_error_contract` — unregistered policy, unregistered aggregate, and absent id.

`cargo clippy -p es-replay-persistence --tests` is clean (only the pre-existing unrelated `explicit_counter_loop` warning in `read_feed`). All new and existing dead-letter/status tests pass.

Closes #126
