### PR TITLE
refactor(persistence): silence explicit_counter_loop in read_feed

### DIFF
--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -1065,14 +1065,12 @@ async fn read_feed(
     let rows = qb.build().fetch_all(pool).await.map_err(crate::db_error)?;
 
     let mut feed = Vec::with_capacity(rows.len());
-    let mut expected = cursor + 1;
-    for row in rows {
+    for (expected, row) in (cursor + 1..).zip(rows) {
         let global_position: i64 = row.get("global_position");
         if global_position != expected {
             // Gap: stop here and let the hole fill on a later poll.
             break;
         }
-        expected += 1;
 
         let is_snapshot: bool = row.get("compacted_snapshot");
         if is_snapshot {


### PR DESCRIPTION
## Summary

Resolves the `clippy::explicit_counter_loop` warning in `read_feed` (introduced with the O(1) policy-runner refactor in #129).

The gap-detection loop manually incremented an `expected` position counter. Replaced it with an open-ended range zipped over the rows:

```rust
for (expected, row) in (cursor + 1..).zip(rows) {
    let global_position: i64 = row.get("global_position");
    if global_position != expected { break; } // gap → fill on a later poll
    ...
}
```

Behaviour is unchanged: the feed still stops at the first non-contiguous `global_position`, and synthetic compaction snapshots still advance the cursor while delivering nothing.

## Validation

- `cargo clippy -p es-replay-persistence --tests` is now warning-free.
- `cargo test -p es-replay-persistence --no-run` compiles.