### PR TITLE
feat(persistence): discard_dead_letter without re-execution

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,9 +78,11 @@ _Avoid_: reprocess, requeue, redrive.
 ### Discard
 
 The _controlling_ act of an operator judging a [Dead letter]'s reaction
-permanently unrecoverable and dropping the record **without** re-executing it. The
-counterpart to [Retry]; together they are the controlling actions over a Policy's
-failures that [Policy status] only observes.
+permanently unrecoverable and retiring the record from the active set
+**without** re-executing it. The record is archived rather than destroyed, so
+the failure history is never lost. The counterpart to [Retry]; together they are
+the controlling actions over a Policy's failures that [Policy status] only
+observes.
 _Avoid_: dismiss, drop, ignore.
 
 ### Policy status

--- a/README.md
+++ b/README.md
@@ -2109,9 +2109,57 @@ LIMIT  20;
 
 -- Look up the original event for manual replay
 SELECT * FROM events WHERE id = '<event_id from dead letter>';
+```
 
--- Discard a resolved dead-letter
-DELETE FROM policy_dead_letters WHERE id = <id>;
+#### Retrying and discarding dead letters
+
+Two operator controls on `PolicyRunner` resolve a parked dead letter out of
+band. Both take **no** advisory lock and **never** move the policy cursor:
+
+| Method | Reaction | Outcome |
+|--------|----------|---------|
+| `retry_dead_letter(id)` | Re-runs the policy's reaction against **current** aggregate state through the same `Cqrs` path the live drain uses. | `Resolved` (succeeded, or now declined with a `BusinessRuleViolation`), `StillFailing` (re-parked in place with the fresh error), or `NotFound`. |
+| `discard_dead_letter(id)` | None — pure bookkeeping: no `react`, no command, no new event. | `Discarded` or `NotFound`. |
+
+```rust,ignore
+use replay_persistence::{DeadLetterRetry, DeadLetterDiscard};
+
+// Give a parked failure another chance against today's state.
+match runner.retry_dead_letter(id).await? {
+    DeadLetterRetry::Resolved => { /* recovered: no longer Degraded */ }
+    DeadLetterRetry::StillFailing => { /* updated in place, stays Degraded */ }
+    DeadLetterRetry::NotFound => { /* nothing matched the id */ }
+}
+
+// Or give up on it permanently.
+match runner.discard_dead_letter(id).await? {
+    DeadLetterDiscard::Discarded => { /* archived */ }
+    DeadLetterDiscard::NotFound => { /* nothing matched the id */ }
+}
+```
+
+Neither method destroys data. When a dead letter leaves the active set —
+resolved by a retry or discarded — the runner **moves** it into the
+`discarded_dead_letters` archive in a single statement, so `policy_dead_letters`
+keeps exactly the parked failures the status read model reports while the full
+history is preserved for audit:
+
+```sql
+CREATE TABLE IF NOT EXISTS discarded_dead_letters (
+    id               BIGSERIAL   PRIMARY KEY,
+    dead_letter_id   BIGINT      NOT NULL,   -- id it had in policy_dead_letters
+    policy_name      TEXT        NOT NULL,
+    global_position  BIGINT      NOT NULL,
+    event_id         UUID        NOT NULL,
+    error_kind       TEXT        NOT NULL,
+    error_message    TEXT        NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL,   -- when the dead letter was written
+    reason           TEXT        NOT NULL,   -- 'retried' | 'discarded'
+    discarded_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_discarded_dead_letters_policy
+    ON discarded_dead_letters (policy_name, discarded_at DESC);
 ```
 
 #### `A::Error: Into<replay::Error>` migration note

--- a/persistence/src/lib.rs
+++ b/persistence/src/lib.rs
@@ -20,7 +20,8 @@ pub use inline_projection::InlineProjection;
 pub use persisted_event::PersistedEvent;
 pub use policy::{Dispatch, Policy, StartAt};
 pub use policy_runner::{
-    DeadLetterRetry, PolicyRunner, PolicyRunnerBuilder, PolicyRunnerDaemon, REPLAY_NOTIFY_CHANNEL,
+    DeadLetterDiscard, DeadLetterRetry, PolicyRunner, PolicyRunnerBuilder, PolicyRunnerDaemon,
+    REPLAY_NOTIFY_CHANNEL,
 };
 pub use policy_status::{PolicyCondition, PolicyStatus, PolicyStatusStore};
 pub use query::Query;
@@ -45,9 +46,10 @@ pub mod prelude {
 
     // Persistence types from this crate
     pub use super::{
-        AggregateVersion, Cqrs, DeadLetterRetry, Dispatch, EventSink, EventStore,
-        InMemoryEventStore, InlineProjection, NoSink, PersistedEvent, Policy, PolicyCondition,
-        PolicyRunner, PolicyRunnerBuilder, PolicyRunnerDaemon, PolicyStatus, PolicyStatusStore,
-        PostgresEventStore, PostgresInlineProjection, Query, StartAt, StreamFilter,
+        AggregateVersion, Cqrs, DeadLetterDiscard, DeadLetterRetry, Dispatch, EventSink,
+        EventStore, InMemoryEventStore, InlineProjection, NoSink, PersistedEvent, Policy,
+        PolicyCondition, PolicyRunner, PolicyRunnerBuilder, PolicyRunnerDaemon, PolicyStatus,
+        PolicyStatusStore, PostgresEventStore, PostgresInlineProjection, Query, StartAt,
+        StreamFilter,
     };
 }

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -225,6 +225,15 @@ pub enum DeadLetterRetry {
     NotFound,
 }
 
+/// Outcome of [`PolicyRunner::discard_dead_letter`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeadLetterDiscard {
+    /// The dead-letter row was deleted.
+    Discarded,
+    /// No dead-letter row matched the supplied id: nothing to do.
+    NotFound,
+}
+
 /// Native runner that drives registered policies against the event feed.
 pub struct PolicyRunner {
     cqrs: Cqrs<PostgresEventStore>,
@@ -401,6 +410,32 @@ impl PolicyRunner {
                 .map_err(crate::db_error)?;
                 Ok(DeadLetterRetry::StillFailing)
             }
+        }
+    }
+
+    /// Discard a parked dead letter without re-running its reaction.
+    ///
+    /// Pure bookkeeping: deletes the dead-letter row `id` by primary key.
+    /// Unlike [`retry_dead_letter`](Self::retry_dead_letter) it performs **no**
+    /// `react`, executes **no** command, and therefore produces **no** new
+    /// aggregate event. It takes no advisory lock and never touches
+    /// `policy_cursors`. Once the row is gone, [`PolicyStatusStore::list`]
+    /// reports the policy leaving `Degraded` exactly as it does after a
+    /// successful retry.
+    ///
+    /// Returns [`DeadLetterDiscard::NotFound`] when no row matches `id` — a
+    /// defined no-op, never a panic.
+    pub async fn discard_dead_letter(&self, id: i64) -> Result<DeadLetterDiscard, replay::Error> {
+        let result = sqlx::query("DELETE FROM policy_dead_letters WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(crate::db_error)?;
+
+        if result.rows_affected() == 0 {
+            Ok(DeadLetterDiscard::NotFound)
+        } else {
+            Ok(DeadLetterDiscard::Discarded)
         }
     }
 

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -297,7 +297,8 @@ impl PolicyRunner {
     /// settled **after** execution:
     ///
     /// - the reaction succeeds, or the aggregate now declines it with a
-    ///   `BusinessRuleViolation` → the row is **deleted**
+    ///   `BusinessRuleViolation` → the row is **archived** into
+    ///   `discarded_dead_letters` with reason `retried`
     ///   ([`DeadLetterRetry::Resolved`]).
     /// - the reaction fails permanently again → the existing row is **updated
     ///   in place** with the fresh error ([`DeadLetterRetry::StillFailing`]);
@@ -378,7 +379,7 @@ impl PolicyRunner {
                 Ok(()) => {}
                 Err(e) if e.kind() == replay::ErrorKind::BusinessRuleViolation => {
                     // Stale reaction: the aggregate now declines it. Clean
-                    // resolution — fall through to delete the row.
+                    // resolution — fall through to archive the row.
                 }
                 Err(e) => {
                     failure = Some(e);
@@ -389,11 +390,7 @@ impl PolicyRunner {
 
         match failure {
             None => {
-                sqlx::query("DELETE FROM policy_dead_letters WHERE id = $1")
-                    .bind(id)
-                    .execute(&self.pool)
-                    .await
-                    .map_err(crate::db_error)?;
+                move_dead_letter_to_archive(&self.pool, id, "retried").await?;
                 Ok(DeadLetterRetry::Resolved)
             }
             Some(error) => {
@@ -415,27 +412,24 @@ impl PolicyRunner {
 
     /// Discard a parked dead letter without re-running its reaction.
     ///
-    /// Pure bookkeeping: deletes the dead-letter row `id` by primary key.
-    /// Unlike [`retry_dead_letter`](Self::retry_dead_letter) it performs **no**
+    /// Pure bookkeeping: **archives** the dead-letter row `id` into
+    /// `discarded_dead_letters` (reason `discarded`) in a single statement —
+    /// a soft delete that removes it from the active set the status read model
+    /// scans while keeping the audit trail. Unlike
+    /// [`retry_dead_letter`](Self::retry_dead_letter) it performs **no**
     /// `react`, executes **no** command, and therefore produces **no** new
     /// aggregate event. It takes no advisory lock and never touches
-    /// `policy_cursors`. Once the row is gone, [`PolicyStatusStore::list`]
-    /// reports the policy leaving `Degraded` exactly as it does after a
-    /// successful retry.
+    /// `policy_cursors`. Once the row leaves the active table,
+    /// [`PolicyStatusStore::list`] reports the policy leaving `Degraded`
+    /// exactly as it does after a successful retry.
     ///
-    /// Returns [`DeadLetterDiscard::NotFound`] when no row matches `id` — a
-    /// defined no-op, never a panic.
+    /// Returns [`DeadLetterDiscard::NotFound`] when no active row matches `id`
+    /// — a defined no-op, never a panic.
     pub async fn discard_dead_letter(&self, id: i64) -> Result<DeadLetterDiscard, replay::Error> {
-        let result = sqlx::query("DELETE FROM policy_dead_letters WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await
-            .map_err(crate::db_error)?;
-
-        if result.rows_affected() == 0 {
-            Ok(DeadLetterDiscard::NotFound)
-        } else {
+        if move_dead_letter_to_archive(&self.pool, id, "discarded").await? {
             Ok(DeadLetterDiscard::Discarded)
+        } else {
+            Ok(DeadLetterDiscard::NotFound)
         }
     }
 
@@ -1048,6 +1042,41 @@ async fn write_dead_letter(
     .await
     .map_err(crate::db_error)?;
     Ok(())
+}
+
+/// Move a dead letter out of the active `policy_dead_letters` table into the
+/// `discarded_dead_letters` archive in a single statement, recording why it
+/// left (`reason`: `retried` or `discarded`).
+///
+/// The `DELETE ... RETURNING` feeds the `INSERT` so the row is removed from the
+/// active set and preserved for audit atomically. Returns `true` when a row was
+/// moved, `false` when no active row matched `id`.
+async fn move_dead_letter_to_archive(
+    pool: &Pool<Postgres>,
+    id: i64,
+    reason: &str,
+) -> Result<bool, replay::Error> {
+    let result = sqlx::query(
+        "WITH moved AS ( \
+             DELETE FROM policy_dead_letters \
+             WHERE id = $1 \
+             RETURNING id, policy_name, global_position, event_id, error_kind, \
+                       error_message, created_at \
+         ) \
+         INSERT INTO discarded_dead_letters \
+             (dead_letter_id, policy_name, global_position, event_id, error_kind, \
+              error_message, created_at, reason) \
+         SELECT id, policy_name, global_position, event_id, error_kind, \
+                error_message, created_at, $2 \
+         FROM moved",
+    )
+    .bind(id)
+    .bind(reason)
+    .execute(pool)
+    .await
+    .map_err(crate::db_error)?;
+
+    Ok(result.rows_affected() > 0)
 }
 
 /// Load a single event by its primary key, shaped exactly like [`read_feed`]

--- a/persistence/src/policy_runner.rs
+++ b/persistence/src/policy_runner.rs
@@ -216,7 +216,8 @@ impl PolicyRunnerBuilder {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeadLetterRetry {
     /// The reaction succeeded, or the aggregate now declines it with a
-    /// `BusinessRuleViolation`: the dead-letter row was deleted.
+    /// `BusinessRuleViolation`: the dead-letter row was archived into
+    /// `discarded_dead_letters` (reason `retried`).
     Resolved,
     /// The reaction failed permanently again: the existing row was updated in
     /// place with the fresh error. No second row was ever inserted.
@@ -228,7 +229,8 @@ pub enum DeadLetterRetry {
 /// Outcome of [`PolicyRunner::discard_dead_letter`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeadLetterDiscard {
-    /// The dead-letter row was deleted.
+    /// The dead-letter row was archived into `discarded_dead_letters` (reason
+    /// `discarded`) — a soft delete, not a hard delete.
     Discarded,
     /// No dead-letter row matched the supplied id: nothing to do.
     NotFound,
@@ -390,8 +392,14 @@ impl PolicyRunner {
 
         match failure {
             None => {
-                move_dead_letter_to_archive(&self.pool, id, "retried").await?;
-                Ok(DeadLetterRetry::Resolved)
+                if move_dead_letter_to_archive(&self.pool, id, "retried").await? {
+                    Ok(DeadLetterRetry::Resolved)
+                } else {
+                    // A concurrent discard removed the row between the initial
+                    // SELECT and the archive move: nothing was archived with
+                    // reason `retried`, so report it as NotFound.
+                    Ok(DeadLetterRetry::NotFound)
+                }
             }
             Some(error) => {
                 sqlx::query(

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -3731,8 +3731,19 @@ async fn retry_dead_letter_resolves_and_deletes_row_postgres_test() {
         .expect("retry must not error");
     assert_eq!(outcome, replay_persistence::DeadLetterRetry::Resolved);
 
-    // Row deleted.
+    // Removed from the active set.
     assert_eq!(dead_letter_count(&pg_pool, "retry_fee_policy").await, 0);
+
+    // Archived (soft delete), not destroyed: the row now lives in the archive
+    // tagged with the retry reason and its original id.
+    let archived_reason: String = sqlx::query_scalar(
+        "SELECT reason FROM discarded_dead_letters WHERE dead_letter_id = $1",
+    )
+    .bind(id)
+    .fetch_one(&pg_pool)
+    .await
+    .expect("the resolved dead letter must be archived");
+    assert_eq!(archived_reason, "retried");
 
     // Reaction applied exactly once (balance reflects a single fee charge).
     let account = cqrs
@@ -4022,8 +4033,19 @@ async fn discard_dead_letter_deletes_row_without_side_effects_postgres_test() {
         .expect("discard must not error");
     assert_eq!(outcome, replay_persistence::DeadLetterDiscard::Discarded);
 
-    // Row deleted.
+    // Removed from the active set.
     assert_eq!(dead_letter_count(&pg_pool, "retry_fee_policy").await, 0);
+
+    // Archived (soft delete), not destroyed: the row now lives in the archive
+    // tagged with the discard reason and its original id.
+    let archived_reason: String = sqlx::query_scalar(
+        "SELECT reason FROM discarded_dead_letters WHERE dead_letter_id = $1",
+    )
+    .bind(id)
+    .fetch_one(&pg_pool)
+    .await
+    .expect("the discarded dead letter must be archived");
+    assert_eq!(archived_reason, "discarded");
 
     // No new event: the events table is unchanged and the target aggregate was
     // never charged.

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -3977,6 +3977,110 @@ async fn retry_dead_letter_error_contract_postgres_test() {
     assert_eq!(dead_letter_count(&pg_pool, "retry_fee_policy").await, 1);
 }
 
+// ── Dead-letter discard: discard_dead_letter primitive (issue #127) ───────────
+
+/// Discard is pure bookkeeping: it deletes the parked dead letter, produces no
+/// new event on the target aggregate, recovers the policy from `Degraded`,
+/// takes no advisory lock, never moves the cursor, and treats an absent id as a
+/// defined no-op.
+#[tokio::test]
+async fn discard_dead_letter_deletes_row_without_side_effects_postgres_test() {
+    let target = IdempotentFeeAccountUrn::new("discard-target").unwrap();
+    let (_container, pg_pool, cqrs, id) = manufacture_dead_letter(
+        RetryFeePolicy {
+            target: target.clone(),
+            fee: 5.0,
+        },
+        "retry_fee_policy",
+    )
+    .await;
+
+    assert_eq!(dead_letter_count(&pg_pool, "retry_fee_policy").await, 1);
+    assert_eq!(
+        policy_condition(&pg_pool, "retry_fee_policy").await,
+        replay_persistence::PolicyCondition::Degraded,
+        "a parked dead letter must read as Degraded"
+    );
+
+    let events_before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events")
+        .fetch_one(&pg_pool)
+        .await
+        .unwrap();
+    let cursor_before: i64 =
+        sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = 'retry_fee_policy'")
+            .fetch_one(&pg_pool)
+            .await
+            .unwrap();
+
+    // Discard runner: it does not even register the target aggregate's
+    // services, because discard never executes a command.
+    let runner = replay_persistence::PolicyRunner::builder(cqrs.clone()).build();
+
+    let outcome = runner
+        .discard_dead_letter(id)
+        .await
+        .expect("discard must not error");
+    assert_eq!(outcome, replay_persistence::DeadLetterDiscard::Discarded);
+
+    // Row deleted.
+    assert_eq!(dead_letter_count(&pg_pool, "retry_fee_policy").await, 0);
+
+    // No new event: the events table is unchanged and the target aggregate was
+    // never charged.
+    let events_after: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events")
+        .fetch_one(&pg_pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        events_before, events_after,
+        "discard must not append any event"
+    );
+    let account = cqrs
+        .fetch_aggregate::<IdempotentFeeAccount>(&target)
+        .await
+        .unwrap();
+    assert_eq!(
+        account.balance, 0.0,
+        "discard must not charge the target aggregate"
+    );
+
+    // Policy recovered: no longer Degraded.
+    assert_ne!(
+        policy_condition(&pg_pool, "retry_fee_policy").await,
+        replay_persistence::PolicyCondition::Degraded,
+        "after discard the policy must no longer be Degraded"
+    );
+
+    // Cursor untouched.
+    let cursor_after: i64 =
+        sqlx::query_scalar("SELECT position FROM policy_cursors WHERE name = 'retry_fee_policy'")
+            .fetch_one(&pg_pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        cursor_before, cursor_after,
+        "discard must not move the cursor"
+    );
+
+    // No advisory lock taken: discard needs no leadership.
+    let advisory_locks: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory'")
+            .fetch_one(&pg_pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        advisory_locks, 0,
+        "discard must not acquire an advisory lock"
+    );
+
+    // Discarding the same id again — now absent — is a defined no-op.
+    let second = runner
+        .discard_dead_letter(id)
+        .await
+        .expect("absent id must not error");
+    assert_eq!(second, replay_persistence::DeadLetterDiscard::NotFound);
+}
+
 // ── Batching: read-batch size and checkpoint-batch size (issue #85) ───────────
 
 /// Policy with a custom read-batch size for testing.

--- a/persistence/tests/integration_tests.rs
+++ b/persistence/tests/integration_tests.rs
@@ -3990,10 +3990,10 @@ async fn retry_dead_letter_error_contract_postgres_test() {
 
 // ── Dead-letter discard: discard_dead_letter primitive (issue #127) ───────────
 
-/// Discard is pure bookkeeping: it deletes the parked dead letter, produces no
-/// new event on the target aggregate, recovers the policy from `Degraded`,
-/// takes no advisory lock, never moves the cursor, and treats an absent id as a
-/// defined no-op.
+/// Discard is pure bookkeeping: it soft-deletes the parked dead letter (moving
+/// it into `discarded_dead_letters`), produces no new event on the target
+/// aggregate, recovers the policy from `Degraded`, takes no advisory lock,
+/// never moves the cursor, and treats an absent id as a defined no-op.
 #[tokio::test]
 async fn discard_dead_letter_deletes_row_without_side_effects_postgres_test() {
     let target = IdempotentFeeAccountUrn::new("discard-target").unwrap();

--- a/persistence/tests/migrations/0011_discarded_dead_letters.sql
+++ b/persistence/tests/migrations/0011_discarded_dead_letters.sql
@@ -1,0 +1,36 @@
+-- Archive of resolved/discarded policy dead letters.
+--
+-- A row in `policy_dead_letters` represents an *active* parked failure that the
+-- policy status read model aggregates.  When a dead letter leaves the active
+-- set — resolved by a successful Retry, or Discarded by an operator for
+-- bookkeeping — the runner MOVES it here in the same statement
+-- (`DELETE ... RETURNING` → `INSERT`) rather than dropping it.  This keeps the
+-- active table (and the status query that scans it) lean while the audit
+-- history is never lost.
+--
+-- Columns:
+--   id              — surrogate key for the archive row.
+--   dead_letter_id  — id the row had in `policy_dead_letters` (traceability).
+--   policy_name     — stable policy name (cursor key), e.g. "fee_policy".
+--   global_position — position of the triggering event in the global feed.
+--   event_id        — UUID of the triggering event.
+--   error_kind      — last ErrorKind text recorded while the row was active.
+--   error_message   — last human-readable error detail.
+--   created_at      — when the dead letter was originally written.
+--   reason          — why it left the active set: 'retried' or 'discarded'.
+--   discarded_at    — when it was archived.
+CREATE TABLE IF NOT EXISTS discarded_dead_letters (
+    id               BIGSERIAL   PRIMARY KEY,
+    dead_letter_id   BIGINT      NOT NULL,
+    policy_name      TEXT        NOT NULL,
+    global_position  BIGINT      NOT NULL,
+    event_id         UUID        NOT NULL,
+    error_kind       TEXT        NOT NULL,
+    error_message    TEXT        NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL,
+    reason           TEXT        NOT NULL CHECK (reason IN ('retried', 'discarded')),
+    discarded_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_discarded_dead_letters_policy
+    ON discarded_dead_letters (policy_name, discarded_at DESC);

--- a/persistence/tests/migrations/0011_discarded_dead_letters.sql
+++ b/persistence/tests/migrations/0011_discarded_dead_letters.sql
@@ -34,3 +34,9 @@ CREATE TABLE IF NOT EXISTS discarded_dead_letters (
 
 CREATE INDEX IF NOT EXISTS idx_discarded_dead_letters_policy
     ON discarded_dead_letters (policy_name, discarded_at DESC);
+
+-- A dead letter is moved here at most once (its BIGSERIAL id is never reused),
+-- so dead_letter_id is unique; the index keeps audit lookups by original id
+-- from degrading into sequential scans as the archive grows.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_discarded_dead_letters_dead_letter_id
+    ON discarded_dead_letters (dead_letter_id);


### PR DESCRIPTION
Closes #127.

## Summary

Adds `PolicyRunner::discard_dead_letter(id)` — the operator's escape hatch for a dead letter whose reaction can never succeed, the unconditional counterpart to `retry_dead_letter` — and reworks dead-letter removal as a **soft delete into an archive** so no failure history is lost.

### Archive instead of hard delete

A new `discarded_dead_letters` table (migration `0011`) holds removed dead letters, with:

- `reason` — `'retried'` or `'discarded'` (CHECK-constrained),
- `dead_letter_id` — back-reference to the original active-table id,
- the original `created_at`, plus `discarded_at`,
- an index on `(policy_name, discarded_at DESC)`.

Both removal paths now **move** the row out of the active `policy_dead_letters` table into the archive in a single `DELETE ... RETURNING → INSERT` statement rather than hard-deleting it:

- retry resolution (`DeadLetterRetry::Resolved`) archives with reason `retried`,
- `discard_dead_letter` archives with reason `discarded`.

The active table keeps exactly the parked failures, so the **policy status read model (`PolicyStatusStore::list`) is unchanged** and stays lean, while the full history is preserved for audit.

Discard is otherwise pure bookkeeping: **no** `react`, **no** command, **no** new aggregate event, no advisory lock, never touches `policy_cursors`. `DeadLetterDiscard { Discarded, NotFound }` reports whether an active row was moved; an absent id is a defined no-op (`NotFound`), never a panic.

## Acceptance criteria

- [x] `discard_dead_letter(id)` exists on `PolicyRunner` (not the read-only `PolicyStatusStore`) and is exported next to it.
- [x] Discarding a parked dead letter removes it from the active set and produces no new event on the target aggregate.
- [x] After discard, `PolicyStatusStore::list()` shows the policy no longer `Degraded`.
- [x] Discarding an absent id is a defined no-op (`NotFound`), not a panic.
- [x] Discard takes no advisory lock and never touches `policy_cursors`.
- [x] Removed dead letters are archived (soft delete), never destroyed — retry-resolved with reason `retried`, discarded with reason `discarded`.
- [x] Covered by Docker-gated Postgres integration tests that manufacture a real dead letter via `drain()`, exercise both paths, and assert the no-side-effect, status-recovery, and archive-with-correct-reason outcomes.

## Validation

- `cargo clippy -p es-replay-persistence --tests` warning-free.
- Dead-letter retry + discard integration tests pass against a real Postgres container.