### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["es", "macros", "persistence", "macros-tests"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Carlos Verdes <cverdes@gmail.com>"]
 license = "MIT"

--- a/macros-tests/Cargo.toml
+++ b/macros-tests/Cargo.toml
@@ -12,8 +12,8 @@ readme.workspace = true
 name = "replay_macros_tests"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.7.0" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.7.0" }
+replay = { package = "es-replay", path = "../es", version = "0.8.0" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.8.0" }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 name = "replay_macros"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.7.0" }
+replay = { package = "es-replay", path = "../es", version = "0.8.0" }
 proc-macro2 = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }

--- a/persistence/Cargo.toml
+++ b/persistence/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["lib"]
 name = "replay_persistence"
 
 [dependencies]
-replay = { package = "es-replay", path = "../es", version = "0.7.0" }
-replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.7.0" }
+replay = { package = "es-replay", path = "../es", version = "0.8.0" }
+replay-macros = { package = "es-replay-macros", path = "../macros", version = "0.8.0" }
 
 serde = { workspace = true }
 serde_with = { workspace = true }


### PR DESCRIPTION
Release 0.8.0.

Bumps the workspace version and the inter-crate path-dependency pins from
0.7.0 to 0.8.0 (the external `urn = "0.7.0"` dependency is unrelated and left
untouched). `Cargo.lock` regenerated; `cargo build` is green.

## Changes since 0.7.0 (all additive)

- feat(persistence): retry_dead_letter primitive with full row lifecycle (#130)
- feat(persistence): discard_dead_letter without re-execution (#132)
- feat(persistence): retry_policy_dead_letters bulk convenience (#133)
- fix(persistence): collapse policy runner connection footprint to O(1) (#129)
- refactor(persistence): range-zip instead of manual loop counter in read_feed (#131)
- docs(adr): record dead-letter retry/discard design (ADR-0007) (#123)

Completes the dead-letter retry/discard control surface (PRD #124) on top of the
policy status read model (#115/#116).

## Migration

One new SQL migration since 0.7.0: `0011_discarded_dead_letters.sql` (the
resolved/discarded dead-letter archive). Adopters must apply it before using the
new retry/discard API. Full upgrade notes will accompany the GitHub release.